### PR TITLE
Merge database schema with Issue #7 requirements

### DIFF
--- a/docs/schema-changes.md
+++ b/docs/schema-changes.md
@@ -312,7 +312,7 @@ WHERE cr.original_work_session_id = 'session-123';
 **Affected Columns (24 total):**
 
 **Audit Trail Columns:**
-- organizations, users, providers, sessions, affiliations, classrooms, teaching_assistants, challenges, challenge_solutions, knowledge_base: `created_at`, `updated_at`
+- organizations, users, providers, sessions, affiliations, classrooms, teaching_assistants, challenges, knowledge_base: `created_at`, `updated_at`
 - organizations, users, affiliations, classrooms, challenges: `deleted_at`
 - user_classrooms: `deleted_at`
 
@@ -391,13 +391,12 @@ WHERE cr.original_work_session_id = 'session-123';
 2. **Selects TA** (or uses default) → Creates `work_session` with `teaching_assistant_id`
 3. **Asks TA question** → Stores in `user_interactions_on_challenges`, updates `work_sessions.last_message_at`
 4. **Runs code** → Updates interaction with stdin/stdout
-5. **Saves work** → Updates `challenge_solutions` with latest code + chat_history snapshot
+5. **Saves work** → Solution state tracked via `user_interactions_on_challenges` with full conversation history
 6. **Closes session** → Sets `work_sessions.ended_at`
-7. **Reopens challenge later** → Loads from `challenge_solutions`, can switch to different TA
+7. **Reopens challenge later** → Loads interaction history, can switch to different TA
 
 ### Teacher Reviews Student Progress
-1. **Queries `challenge_solutions`** → Sees final solution and cached chat history
-2. **Queries `user_interactions_on_challenges`** → Analyzes full conversation history across all work sessions
+1. **Queries `user_interactions_on_challenges`** → Analyzes full conversation history and solution development across all work sessions
 3. **Queries `work_sessions`** → Identifies which TA was used, session duration, completion status
 4. **Evaluates based on journey** → Reviews how student asked questions, iterated on solutions, engaged with TA
 
@@ -440,13 +439,8 @@ If migrating from initial schema:
 17. Migrate existing sessions: assign a default TA based on historical model usage
 
 ### Phase 4: Solutions & Interactions
-18. Restructure `challenge_solutions`:
-    - Remove `class_id` FK (redundant via challenge)
-    - Remove `work_session_id` FK (current solution transcends work sessions)
-    - Add `chat_history` (JSONB)
-    - Add `code`, `stdin`, `stdout` (TEXT)
-    - Add `UNIQUE (user_id, challenge_id)`
-19. **Remove `challenge_solutions_history` table** (no longer needed; history tracked via `user_interactions_on_challenges`)
+18. **Remove `challenge_solutions` table** → Solution state fully tracked via `user_interactions_on_challenges` with conversation history
+19. **Remove `challenge_solutions_history` table** → History tracked via `user_interactions_on_challenges`
 20. Enhance `challenges` with `title`, `support_materials`, `possible_solutions`, `deleted_at`
 
 ### Phase 5: A/B Testing Framework
@@ -468,6 +462,19 @@ If migrating from initial schema:
     - Security-critical expirations: expires_at, access_token_expires_at, refresh_token_expires_at
     - Event timestamps: enrolled_at, last_message_at, ended_at, replayed_at
 31. For existing databases, run: `ALTER TABLE table_name ALTER COLUMN column_name TYPE TIMESTAMPTZ USING column_name AT TIME ZONE 'UTC'`
+
+### Phase 8: Schema Refinements & Multi-Org Support
+32. Add `model_parameters JSONB` to `models` table
+    - Stores flexible model configuration: `{"temperature": 0.7, "max_tokens": 2000, "top_p": 1.0}`
+33. Add `created_by_organization_id UUID` to `teaching_assistants` table
+    - NULL = system-created TA (globally available)
+    - Non-NULL = organization-specific TA
+    - Foreign key: `ON DELETE SET NULL` (org deletion converts TAs to global)
+34. Add index `idx_teaching_assistants_organization` for multi-tenant query performance
+35. **Remove `challenge_solutions` table** → Solution state fully tracked via `user_interactions_on_challenges`
+36. Remove execution fields (`code`, `stdin`, `stdout`) from `replay_interactions`
+    - Replay interactions focus on conversational A/B testing
+    - Execution context remains in original `user_interactions_on_challenges`
 
 ### Post-Migration Tasks
 - Seed `teaching_assistants` with initial TA configurations (e.g., Bob v1, Alice v1)

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -137,6 +137,7 @@ CREATE TABLE models (
     version TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
+    model_parameters JSONB, -- Configuration: {"temperature": 0.7, "max_tokens": 2000, "top_p": 1.0}
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (name, version)
 );
@@ -144,24 +145,24 @@ CREATE TABLE models (
 -- TEACHING ASSISTANTS (versioned TA configurations)
 CREATE TABLE teaching_assistants (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    alias VARCHAR(50) NOT NULL,
-    -- 'Bob', 'Alice', etc.
+    alias VARCHAR(50) NOT NULL, -- 'Bob', 'Alice', etc.
     version INTEGER NOT NULL,
     model_id UUID NOT NULL,
     system_prompt TEXT NOT NULL,
-    description TEXT,
-    -- What changed in this version
-    target_audience VARCHAR(50),
-    -- 'beginner', 'advanced', etc.
+    description TEXT, -- What changed in this version
+    target_audience VARCHAR(50), -- 'beginner', 'advanced', etc.
     is_active BOOLEAN DEFAULT false,
+    created_by_organization_id UUID, -- NULL = system-created TA (global), otherwise organization-specific
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE(alias, version),
-    CONSTRAINT fk_teaching_assistants_model FOREIGN KEY (model_id) REFERENCES models(id)
+    CONSTRAINT fk_teaching_assistants_model FOREIGN KEY (model_id) REFERENCES models(id),
+    CONSTRAINT fk_teaching_assistants_organization FOREIGN KEY (created_by_organization_id) REFERENCES organizations(id) ON DELETE SET NULL
 );
 CREATE INDEX idx_teaching_assistants_alias ON teaching_assistants(alias);
 CREATE INDEX idx_teaching_assistants_active ON teaching_assistants(alias, is_active)
 WHERE is_active = true;
+CREATE INDEX idx_teaching_assistants_organization ON teaching_assistants(created_by_organization_id);
 
 -- CHALLENGES
 -- If classroom_id is NULL, the challenge is standalone and accessible by any organization
@@ -235,25 +236,6 @@ CREATE TABLE user_interactions_on_challenges (
 CREATE INDEX idx_interactions_work_session_id ON user_interactions_on_challenges (work_session_id);
 CREATE INDEX idx_interactions_challenge_id ON user_interactions_on_challenges (challenge_id);
 
--- CHALLENGE SOLUTIONS (Current)
-CREATE TABLE challenge_solutions (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL,
-    challenge_id UUID NOT NULL,
-    solution TEXT NOT NULL,
-    chat_history JSONB,
-    code TEXT,
-    stdin TEXT,
-    stdout TEXT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    CONSTRAINT fk_solutions_user FOREIGN KEY (user_id) REFERENCES users(id),
-    CONSTRAINT fk_solutions_challenge FOREIGN KEY (challenge_id) REFERENCES challenges(id),
-    UNIQUE (user_id, challenge_id)
-);
-CREATE INDEX idx_solutions_user_id ON challenge_solutions (user_id);
-CREATE INDEX idx_solutions_challenge_id ON challenge_solutions (challenge_id);
-
 -- KNOWLEDGE BASE (RAG)
 CREATE TABLE knowledge_base (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -300,9 +282,6 @@ CREATE TABLE replay_interactions (
     original_interaction_id UUID,
     user_prompt TEXT NOT NULL,
     model_response TEXT NOT NULL,
-    code TEXT,
-    stdin TEXT,
-    stdout TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     CONSTRAINT fk_replay_interactions_replay FOREIGN KEY (replay_id) REFERENCES conversation_replays(id) ON DELETE CASCADE,
     CONSTRAINT fk_replay_interactions_original FOREIGN KEY (original_interaction_id) REFERENCES user_interactions_on_challenges(id)


### PR DESCRIPTION
## Summary

Enhanced the initial database schema by incorporating requirements from Issue #7 and adding multi-organization user support with OAuth authentication.

### Multi-Organization & Auth
- Users can belong to multiple organizations via `affiliations` table
- Each affiliation has its own role (student/teacher/coordinator/admin)
- OAuth support via `providers` table (Google, GitHub, etc.)
- Auth `sessions` table for token-based login
- `verifications` table for email/password verification flows
- Email uniqueness via partial index (allows reuse after soft-delete)

### Core Teaching Assistant Features
- `llm_interactions` table for student-LLM conversation history
- `work_sessions` table tracks challenge attempts (renamed from `sessions`)
- `challenge_solutions` + `challenge_solutions_history` for audit trail
- `models` table for LLM configuration management
- `knowledge_base` with org/class/challenge scoping for RAG

### Key Design Decisions
- Standalone challenges (`class_id` NULL) are accessible by any organization
- Soft deletes on users, organizations, classes, challenges, affiliations, user_classes
- Expanded role hierarchy: admin > coordinator > teacher > student

See `docs/schema-changes.md` for detailed migration notes.