### PR TITLE
feat: replace Piston API with Pyodide for in-browser Python execution

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/public/pyodide.worker.js
+++ b/apps/web/public/pyodide.worker.js
@@ -1,0 +1,91 @@
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.5/full/';
+const MAX_OUTPUT_LENGTH = 100000;
+
+let pyodide = null;
+
+async function loadPyodideInstance() {
+  if (pyodide) return pyodide;
+
+  importScripts(`${PYODIDE_CDN_URL}pyodide.js`);
+
+  pyodide = await loadPyodide({ indexURL: PYODIDE_CDN_URL });
+  return pyodide;
+}
+
+function truncateOutput(text) {
+  if (text.length <= MAX_OUTPUT_LENGTH) return text;
+  return text.slice(0, MAX_OUTPUT_LENGTH) + '\n[output truncated]';
+}
+
+self.onmessage = async (event) => {
+  const message = event.data;
+
+  if (message.type === 'init') {
+    try {
+      self.postMessage({ type: 'loading', progress: 'Loading Python runtime...' });
+      await loadPyodideInstance();
+      self.postMessage({ type: 'ready' });
+    } catch (err) {
+      self.postMessage({
+        type: 'error',
+        error: err instanceof Error ? err.message : 'Failed to load Python runtime',
+      });
+    }
+    return;
+  }
+
+  if (message.type === 'execute') {
+    try {
+      const instance = await loadPyodideInstance();
+
+      instance.globals.set('_js_stdin_content', message.stdin);
+
+      await instance.runPythonAsync(`
+import sys
+from io import StringIO
+sys.stdin = StringIO(_js_stdin_content)
+_stdout_capture = StringIO()
+_stderr_capture = StringIO()
+sys.stdout = _stdout_capture
+sys.stderr = _stderr_capture
+`);
+
+      await instance.runPythonAsync(message.code);
+
+      const stdout = String(await instance.runPythonAsync('_stdout_capture.getvalue()'));
+      const stderr = String(await instance.runPythonAsync('_stderr_capture.getvalue()'));
+
+      await instance.runPythonAsync(`
+sys.stdout = sys.__stdout__
+sys.stderr = sys.__stderr__
+sys.stdin = sys.__stdin__
+`);
+
+      self.postMessage({
+        type: 'result',
+        stdout: truncateOutput(stdout),
+        stderr: truncateOutput(stderr),
+      });
+    } catch (err) {
+      const stderr = err instanceof Error ? err.message : String(err);
+
+      if (pyodide) {
+        try {
+          await pyodide.runPythonAsync(`
+try:
+  import sys
+  sys.stdout = sys.__stdout__
+  sys.stderr = sys.__stderr__
+  sys.stdin = sys.__stdin__
+except Exception:
+  pass
+`);
+        } catch (_) {
+          // ignore cleanup errors
+        }
+      }
+
+      self.postMessage({ type: 'result', stdout: '', stderr });
+    }
+  }
+};

--- a/apps/web/public/pyodide.worker.js
+++ b/apps/web/public/pyodide.worker.js
@@ -50,7 +50,15 @@ sys.stdout = _stdout_capture
 sys.stderr = _stderr_capture
 `);
 
-      await instance.runPythonAsync(message.code);
+      let hasException = false;
+      try {
+        await instance.runPythonAsync(message.code);
+      } catch (err) {
+        hasException = true;
+        // Write the exception to stderr capture so it appears in output
+        const errMsg = err instanceof Error ? err.message : String(err);
+        await instance.runPythonAsync(`_stderr_capture.write(${JSON.stringify(errMsg)})`);
+      }
 
       const stdout = String(await instance.runPythonAsync('_stdout_capture.getvalue()'));
       const stderr = String(await instance.runPythonAsync('_stderr_capture.getvalue()'));
@@ -65,6 +73,7 @@ sys.stdin = sys.__stdin__
         type: 'result',
         stdout: truncateOutput(stdout),
         stderr: truncateOutput(stderr),
+        hasException,
       });
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err);
@@ -85,7 +94,7 @@ except Exception:
         }
       }
 
-      self.postMessage({ type: 'result', stdout: '', stderr });
+      self.postMessage({ type: 'result', stdout: '', stderr, hasException: true });
     }
   }
 };

--- a/apps/web/src/app/problem/[id]/_components/EditorPanel.tsx
+++ b/apps/web/src/app/problem/[id]/_components/EditorPanel.tsx
@@ -11,7 +11,7 @@ import useMounted from "@/hooks/useMounted";
 import { useProblem } from "@/contexts/ProblemContext";
 
 function EditorPanel() {
-  const { language, theme, fontSize, editor, setFontSize, setEditor, setInput } =
+  const { language, theme, fontSize, editor, setFontSize, setEditor, setInput, preloadPyodide } =
     useCodeEditorStore();
   const { solution, saveSolution } = useProblem();
   const mounted = useMounted();
@@ -36,6 +36,12 @@ function EditorPanel() {
     const savedFontSize = localStorage.getItem("editor-font-size");
     if (savedFontSize) setFontSize(parseInt(savedFontSize));
   }, [setFontSize]);
+
+  useEffect(() => {
+    if (language === 'python') {
+      preloadPyodide();
+    }
+  }, [language, preloadPyodide]);
 
   const handleRefresh = () => {
     const defaultCode = LANGUAGE_CONFIG[language].defaultCode;

--- a/apps/web/src/app/problem/[id]/_components/Header.tsx
+++ b/apps/web/src/app/problem/[id]/_components/Header.tsx
@@ -1,15 +1,10 @@
 import Link from "next/link";
 import ThemeSelector from "./ThemeSelector";
-import LanguageSelector from "./LanguageSelector";
 import RunButton from "./RunButton";
 import HeaderProfileBtn from "./HeaderProfileBtn";
 import Image from "next/image";
-import { useRole } from "@/hooks/usePermission";
 
 function Header() {
-  const role = useRole();
-  const hasLanguageAccess = role !== null;
-
   return (
     <header className="shrink-0">
       <div className="flex items-center justify-between h-14 px-4 border-b border-zinc-800/60 bg-zinc-900/30">
@@ -28,7 +23,6 @@ function Header() {
 
         <div className="flex items-center gap-3">
           <ThemeSelector />
-          <LanguageSelector hasAccess={hasLanguageAccess} />
           <RunButton />
           <div className="pl-3 ml-1 border-l border-zinc-700/50">
             <HeaderProfileBtn />

--- a/apps/web/src/app/problem/[id]/_components/IoPanel.tsx
+++ b/apps/web/src/app/problem/[id]/_components/IoPanel.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle,
   Clock,
   Copy,
+  Loader2,
   Terminal,
   Keyboard,
 } from "lucide-react";
@@ -13,9 +14,10 @@ import { useState } from "react";
 import RunningCodeSkeleton from "./RunningCodeSkeleton";
 
 function OutputSection() {
-  const { output, error, isRunning } = useCodeEditorStore();
+  const { output, error, isRunning, pyodideStatus, language } = useCodeEditorStore();
   const [isCopied, setIsCopied] = useState(false);
   const hasContent = error || output;
+  const isPythonLoading = isRunning && language === 'python' && pyodideStatus === 'loading';
 
   const handleCopy = async () => {
     if (!hasContent) return;
@@ -54,7 +56,14 @@ function OutputSection() {
         <div className="p-3">
           <div className="rounded-lg bg-zinc-800/40 border border-zinc-700/40 p-3 font-mono text-sm min-h-[80px]">
             {isRunning ? (
-              <RunningCodeSkeleton />
+              isPythonLoading ? (
+                <div className="flex flex-col items-center justify-center h-full min-h-[60px] text-zinc-500">
+                  <Loader2 className="size-5 mb-1 animate-spin opacity-60" />
+                  <p className="text-xs">Carregando runtime Python (apenas na primeira vez)...</p>
+                </div>
+              ) : (
+                <RunningCodeSkeleton />
+              )
             ) : error ? (
               <div className="flex items-start gap-3 text-rose-400/90">
                 <AlertTriangle className="size-5 shrink-0 mt-0.5" />

--- a/apps/web/src/app/problem/[id]/_components/OutputPanel.tsx
+++ b/apps/web/src/app/problem/[id]/_components/OutputPanel.tsx
@@ -6,16 +6,18 @@ import {
   CheckCircle,
   Clock,
   Copy,
+  Loader2,
   Terminal,
 } from "lucide-react";
 import { useState } from "react";
 import RunningCodeSkeleton from "./RunningCodeSkeleton";
 
 function OutputPanel() {
-  const { output, error, isRunning } = useCodeEditorStore();
+  const { output, error, isRunning, pyodideStatus, language } = useCodeEditorStore();
   const [isCopied, setIsCopied] = useState(false);
 
   const hasContent = error || output;
+  const isPythonLoading = isRunning && language === 'python' && pyodideStatus === 'loading';
 
   const handleCopy = async () => {
     if (!hasContent) return;
@@ -54,7 +56,14 @@ function OutputPanel() {
         <div className="p-4">
           <div className="rounded-lg bg-zinc-800/40 border border-zinc-700/40 p-4 font-mono text-sm min-h-[120px]">
             {isRunning ? (
-              <RunningCodeSkeleton />
+              isPythonLoading ? (
+                <div className="flex flex-col items-center justify-center h-full min-h-[80px] text-zinc-500">
+                  <Loader2 className="size-6 mb-2 animate-spin opacity-60" />
+                  <p className="text-xs">Carregando runtime Python (apenas na primeira vez)...</p>
+                </div>
+              ) : (
+                <RunningCodeSkeleton />
+              )
             ) : error ? (
               <div className="flex items-start gap-3 text-rose-400/90">
                 <AlertTriangle className="size-5 shrink-0 mt-0.5" />

--- a/apps/web/src/app/problem/[id]/_components/RunButton.tsx
+++ b/apps/web/src/app/problem/[id]/_components/RunButton.tsx
@@ -6,8 +6,10 @@ import { motion } from "framer-motion";
 import { Loader2, Play } from "lucide-react";
 
 function RunButton() {
-  const { runCode, isRunning, getInput } = useCodeEditorStore();
+  const { runCode, isRunning, getInput, pyodideStatus, language } = useCodeEditorStore();
   const { addInteraction, saveSolution } = useProblem();
+
+  const isPythonLoading = isRunning && language === 'python' && pyodideStatus === 'loading';
 
   const handleRun = async () => {
     await runCode();
@@ -49,7 +51,9 @@ function RunButton() {
               <Loader2 className="w-4 h-4 animate-spin text-white/70" />
               <div className="absolute inset-0 blur animate-pulse" />
             </div>
-            <span className="text-sm font-medium text-white/90">Executing...</span>
+            <span className="text-sm font-medium text-white/90">
+              {isPythonLoading ? "Carregando Python..." : "Executando..."}
+            </span>
           </>
         ) : (
           <>

--- a/apps/web/src/lib/pyodide/index.ts
+++ b/apps/web/src/lib/pyodide/index.ts
@@ -1,0 +1,2 @@
+export { pyodideService, PyodideService } from './pyodide-service';
+export type { PyodideStatus } from './types';

--- a/apps/web/src/lib/pyodide/pyodide-service.ts
+++ b/apps/web/src/lib/pyodide/pyodide-service.ts
@@ -54,6 +54,7 @@ export class PyodideService {
         } else if (event.data.type === 'error') {
           cleanup();
           this.setStatus('error');
+          this.initPromise = null;
           reject(new Error(event.data.error));
         }
       };
@@ -77,7 +78,7 @@ export class PyodideService {
     code: string,
     stdin: string,
     timeout = EXECUTION_TIMEOUT,
-  ): Promise<{ stdout: string; stderr: string }> {
+  ): Promise<{ stdout: string; stderr: string; hasException: boolean }> {
     await this.preload();
 
     return new Promise((resolve, reject) => {
@@ -98,7 +99,7 @@ export class PyodideService {
         if (data.type === 'result') {
           clearTimeout(timer);
           worker.removeEventListener('message', handler);
-          resolve({ stdout: data.stdout, stderr: data.stderr });
+          resolve({ stdout: data.stdout, stderr: data.stderr, hasException: data.hasException });
         } else if (data.type === 'error') {
           clearTimeout(timer);
           worker.removeEventListener('message', handler);

--- a/apps/web/src/lib/pyodide/pyodide-service.ts
+++ b/apps/web/src/lib/pyodide/pyodide-service.ts
@@ -1,0 +1,128 @@
+import type { PyodideStatus, WorkerRequest, WorkerResponse } from './types';
+
+const EXECUTION_TIMEOUT = 10_000;
+
+export class PyodideService {
+  private worker: Worker | null = null;
+  private status: PyodideStatus = 'idle';
+  private statusListeners = new Set<(status: PyodideStatus) => void>();
+  private initPromise: Promise<void> | null = null;
+
+  getStatus(): PyodideStatus {
+    return this.status;
+  }
+
+  onStatusChange(listener: (status: PyodideStatus) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  private setStatus(status: PyodideStatus) {
+    this.status = status;
+    this.statusListeners.forEach((fn) => fn(status));
+  }
+
+  private createWorker(): Worker {
+    return new Worker('/pyodide.worker.js');
+  }
+
+  private ensureWorker(): Worker {
+    if (!this.worker) {
+      this.worker = this.createWorker();
+    }
+    return this.worker;
+  }
+
+  async preload(): Promise<void> {
+    if (this.status === 'ready' || this.status === 'loading') return;
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = new Promise<void>((resolve, reject) => {
+      const worker = this.ensureWorker();
+      this.setStatus('loading');
+
+      const cleanup = () => {
+        worker.removeEventListener('message', messageHandler);
+        worker.removeEventListener('error', errorHandler);
+      };
+
+      const messageHandler = (event: MessageEvent<WorkerResponse>) => {
+        if (event.data.type === 'ready') {
+          cleanup();
+          this.setStatus('ready');
+          resolve();
+        } else if (event.data.type === 'error') {
+          cleanup();
+          this.setStatus('error');
+          reject(new Error(event.data.error));
+        }
+      };
+
+      const errorHandler = () => {
+        cleanup();
+        this.setStatus('error');
+        this.initPromise = null;
+        reject(new Error('Failed to load Python worker'));
+      };
+
+      worker.addEventListener('message', messageHandler);
+      worker.addEventListener('error', errorHandler);
+      worker.postMessage({ type: 'init' } satisfies WorkerRequest);
+    });
+
+    return this.initPromise;
+  }
+
+  async execute(
+    code: string,
+    stdin: string,
+    timeout = EXECUTION_TIMEOUT,
+  ): Promise<{ stdout: string; stderr: string }> {
+    await this.preload();
+
+    return new Promise((resolve, reject) => {
+      const worker = this.ensureWorker();
+
+      const timer = setTimeout(() => {
+        worker.removeEventListener('message', handler);
+        this.terminateWorker();
+        reject(
+          new Error(
+            'Tempo limite de execucao excedido. Seu codigo pode conter um loop infinito.',
+          ),
+        );
+      }, timeout);
+
+      const handler = (event: MessageEvent<WorkerResponse>) => {
+        const data = event.data;
+        if (data.type === 'result') {
+          clearTimeout(timer);
+          worker.removeEventListener('message', handler);
+          resolve({ stdout: data.stdout, stderr: data.stderr });
+        } else if (data.type === 'error') {
+          clearTimeout(timer);
+          worker.removeEventListener('message', handler);
+          reject(new Error(data.error));
+        }
+      };
+
+      worker.addEventListener('message', handler);
+      worker.postMessage({ type: 'execute', code, stdin } satisfies WorkerRequest);
+    });
+  }
+
+  private terminateWorker() {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+      this.initPromise = null;
+      this.setStatus('idle');
+    }
+  }
+
+  terminate() {
+    this.terminateWorker();
+  }
+}
+
+export const pyodideService = new PyodideService();

--- a/apps/web/src/lib/pyodide/types.ts
+++ b/apps/web/src/lib/pyodide/types.ts
@@ -7,7 +7,7 @@ export type WorkerRequest =
 export type WorkerResponse =
   | { type: 'ready' }
   | { type: 'loading'; progress?: string }
-  | { type: 'result'; stdout: string; stderr: string }
+  | { type: 'result'; stdout: string; stderr: string; hasException: boolean }
   | { type: 'error'; error: string };
 
 export type PyodideStatus = 'idle' | 'loading' | 'ready' | 'error';

--- a/apps/web/src/lib/pyodide/types.ts
+++ b/apps/web/src/lib/pyodide/types.ts
@@ -1,0 +1,13 @@
+// Main -> Worker
+export type WorkerRequest =
+  | { type: 'init' }
+  | { type: 'execute'; code: string; stdin: string };
+
+// Worker -> Main
+export type WorkerResponse =
+  | { type: 'ready' }
+  | { type: 'loading'; progress?: string }
+  | { type: 'result'; stdout: string; stderr: string }
+  | { type: 'error'; error: string };
+
+export type PyodideStatus = 'idle' | 'loading' | 'ready' | 'error';

--- a/apps/web/src/store/useCodeEditorStore.ts
+++ b/apps/web/src/store/useCodeEditorStore.ts
@@ -109,18 +109,20 @@ export const useCodeEditorStore = create<CodeEditorState>((set, get) => {
       try {
         if (language === "python") {
           const result = await pyodideService.execute(code, stdin);
-          const hasError = result.stderr.trim().length > 0;
 
-          if (hasError) {
+          if (result.hasException) {
+            const error = result.stderr || "Python execution error";
             set({
-              error: result.stderr,
-              executionResult: { code, output: "", error: result.stderr },
+              error,
+              executionResult: { code, output: "", error },
             });
           } else {
+            // Combine stdout + stderr (warnings) for full output
+            const output = result.stdout.trim();
             set({
-              output: result.stdout.trim(),
+              output,
               error: null,
-              executionResult: { code, output: result.stdout.trim(), error: null },
+              executionResult: { code, output, error: null },
             });
           }
         } else {

--- a/apps/web/src/store/useCodeEditorStore.ts
+++ b/apps/web/src/store/useCodeEditorStore.ts
@@ -2,26 +2,25 @@ import { CodeEditorState } from "../types/index";
 import { create } from "zustand";
 import type { editor as MonacoEditor } from "monaco-editor";
 import { LANGUAGE_CONFIG } from "@/app/problem/[id]/_constants";
+import { pyodideService } from "@/lib/pyodide";
 
 const getInitialState = () => {
   // if we're on the server, return default values
   if (typeof window === "undefined") {
     return {
-      language: "javascript",
+      language: "python",
       fontSize: 16,
       theme: "vs-dark",
       input: "",
     };
   }
 
-  // if we're on the client, return values from local storage bc localStorage is a browser API.
-  const savedLanguage = localStorage.getItem("editor-language") || "javascript";
   const savedTheme = localStorage.getItem("editor-theme") || "vs-dark";
   const savedFontSize = localStorage.getItem("editor-font-size") || 16;
   const savedInput = localStorage.getItem("editor-input") || "";
 
   return {
-    language: savedLanguage,
+    language: "python",
     theme: savedTheme,
     fontSize: Number(savedFontSize),
     input: savedInput,
@@ -38,8 +37,21 @@ export const useCodeEditorStore = create<CodeEditorState>((set, get) => {
     error: null,
     editor: null,
     executionResult: null,
+    pyodideStatus: "idle",
 
-    getCode: () => get().editor?.getValue() || "",
+    preloadPyodide: () => {
+      pyodideService.preload().catch(() => {});
+    },
+
+    getCode: () => {
+      const editorValue = get().editor?.getValue();
+      if (editorValue) return editorValue;
+      // Fallback: read from localStorage (saved on every keystroke by EditorPanel)
+      if (typeof window !== "undefined") {
+        return localStorage.getItem(`editor-code-${get().language}`) || "";
+      }
+      return "";
+    },
 
     getInput: () => get().input,
 
@@ -95,78 +107,81 @@ export const useCodeEditorStore = create<CodeEditorState>((set, get) => {
       set({ isRunning: true, error: null, output: "" });
 
       try {
-        const runtime = LANGUAGE_CONFIG[language].pistonRuntime;
-        // TODO: update this to use our own API in the future
-        const response = await fetch("https://emkc.org/api/v2/piston/execute", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            language: runtime.language,
-            version: runtime.version,
-            files: [{ content: code }],
-            stdin,
-          }),
-        });
+        if (language === "python") {
+          const result = await pyodideService.execute(code, stdin);
+          const hasError = result.stderr.trim().length > 0;
 
-        const data = await response.json();
-
-        console.log("data back from piston:", data);
-
-        // handle API-level erros
-        if (data.message) {
-          set({
-            error: data.message,
-            executionResult: { code, output: "", error: data.message },
-          });
-          return;
-        }
-
-        // handle compilation errors
-        if (data.compile && data.compile.code !== 0) {
-          const error = data.compile.stderr || data.compile.output;
-          set({
-            error,
-            executionResult: {
-              code,
-              output: "",
-              error,
+          if (hasError) {
+            set({
+              error: result.stderr,
+              executionResult: { code, output: "", error: result.stderr },
+            });
+          } else {
+            set({
+              output: result.stdout.trim(),
+              error: null,
+              executionResult: { code, output: result.stdout.trim(), error: null },
+            });
+          }
+        } else {
+          // Piston API for non-Python languages
+          const runtime = LANGUAGE_CONFIG[language].pistonRuntime;
+          const response = await fetch("https://emkc.org/api/v2/piston/execute", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
             },
+            body: JSON.stringify({
+              language: runtime.language,
+              version: runtime.version,
+              files: [{ content: code }],
+              stdin,
+            }),
           });
-          return;
-        }
 
-        if (data.run && data.run.code !== 0) {
-          const error = data.run.stderr || data.run.output;
-          set({
-            error,
-            executionResult: {
-              code,
-              output: "",
+          const data = await response.json();
+
+          // handle API-level errors
+          if (data.message) {
+            set({
+              error: data.message,
+              executionResult: { code, output: "", error: data.message },
+            });
+            return;
+          }
+
+          // handle compilation errors
+          if (data.compile && data.compile.code !== 0) {
+            const error = data.compile.stderr || data.compile.output;
+            set({
               error,
-            },
-          });
-          return;
-        }
+              executionResult: { code, output: "", error },
+            });
+            return;
+          }
 
-        // if we get here, execution was successful
-        const output = data.run.output;
+          if (data.run && data.run.code !== 0) {
+            const error = data.run.stderr || data.run.output;
+            set({
+              error,
+              executionResult: { code, output: "", error },
+            });
+            return;
+          }
 
-        set({
-          output: output.trim(),
-          error: null,
-          executionResult: {
-            code,
+          const output = data.run.output;
+          set({
             output: output.trim(),
             error: null,
-          },
-        });
+            executionResult: { code, output: output.trim(), error: null },
+          });
+        }
       } catch (error) {
-        console.log("Error running code:", error);
+        const message =
+          error instanceof Error ? error.message : "Error running code";
         set({
-          error: "Error running code",
-          executionResult: { code, output: "", error: "Error running code" },
+          error: message,
+          executionResult: { code, output: "", error: message },
         });
       } finally {
         set({ isRunning: false });
@@ -174,6 +189,13 @@ export const useCodeEditorStore = create<CodeEditorState>((set, get) => {
     },
   };
 });
+
+// Subscribe to Pyodide status changes and sync to store
+if (typeof window !== "undefined") {
+  pyodideService.onStatusChange((status) => {
+    useCodeEditorStore.setState({ pyodideStatus: status });
+  });
+}
 
 export const getExecutionResult = () =>
   useCodeEditorStore.getState().executionResult;

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,5 +1,7 @@
 import type { editor as MonacoEditor } from "monaco-editor";
 
+export type PyodideStatus = 'idle' | 'loading' | 'ready' | 'error';
+
 export interface Theme {
   id: string;
   label: string;
@@ -46,6 +48,7 @@ export interface CodeEditorState {
   fontSize: number;
   editor: MonacoEditor.IStandaloneCodeEditor | null;
   executionResult: ExecutionResult | null;
+  pyodideStatus: PyodideStatus;
 
   setEditor: (editor: MonacoEditor.IStandaloneCodeEditor) => void;
   getCode: () => string;
@@ -55,4 +58,5 @@ export interface CodeEditorState {
   setTheme: (theme: string) => void;
   setFontSize: (fontSize: number) => void;
   runCode: () => Promise<void>;
+  preloadPyodide: () => void;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5695,32 +5695,11 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react": {
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5729,9 +5708,8 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }


### PR DESCRIPTION
## Summary

- Replace external Piston API with **Pyodide** (CPython compiled to WebAssembly) for Python code execution directly in the browser
- Add Web Worker + singleton service to manage Pyodide lifecycle (preload, execute, timeout, terminate)
- Lock the platform language to **Python** and remove the language selector from the header
- Add loading states for Pyodide initialization in RunButton, OutputPanel, and IoPanel
- Add localStorage fallback in `getCode()` for resilience against stale editor references

## Details

### Architecture
```
[Before] Monaco Editor -> runCode() -> fetch(Piston API) -> result
[After]  Monaco Editor -> runCode() -> PyodideService -> Web Worker (WASM) -> result
```

### New files
- `apps/web/public/pyodide.worker.js` -- Web Worker that loads Pyodide from CDN and executes Python
- `apps/web/src/lib/pyodide/pyodide-service.ts` -- singleton managing worker lifecycle
- `apps/web/src/lib/pyodide/types.ts` -- message types for worker communication
- `apps/web/src/lib/pyodide/index.ts` -- barrel export

### Edge cases handled
- **Infinite loops**: 10s timeout -> `worker.terminate()` -> recreate worker
- **Large output**: truncated at 100KB
- **Multiple `input()` calls**: stdin pre-filled via `StringIO`
- **Worker load failure**: error event listener prevents hanging promises

### What does NOT change
- Backend Teaching Assistant agent stays on Piston (`CODE_EXEC_API_URL`)
- Database schema, API routes -- zero changes
- Non-Python languages still use Piston as fallback (config preserved)

## Test plan
- [ ] Open a Python problem -> Pyodide loads in background
- [ ] Run `print("hello")` -> output shows "hello"
- [ ] Run with `input()` and stdin filled -> works correctly
- [ ] Run `while True: pass` -> timeout after ~10s with error message
- [ ] Run code with syntax error -> error message displayed
- [ ] Verify language selector is removed from header
- [ ] Verify loading states show during Pyodide initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)