### PR TITLE
feat(web): admin shell + Phase 2 organizations CRUD UI

### DIFF
--- a/apps/web/src/app/(inside)/_components/navbar.tsx
+++ b/apps/web/src/app/(inside)/_components/navbar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useUser } from "@/contexts/UserContext";
 import { useState, useRef, useEffect } from "react";
 import { PermissionGuard } from "@/components/guards/PermissionGuard";
+import { PlatformAdminGuard } from "@/components/guards/PlatformAdminGuard";
 
 const Navbar = () => {
   const { user, getFirstName, logout } = useUser();
@@ -62,6 +63,14 @@ const Navbar = () => {
                 Criar
               </Link>
             </PermissionGuard>
+            <PlatformAdminGuard>
+              <Link
+                href="/admin"
+                className="px-3 py-1.5 text-sm text-amber-300 hover:text-amber-200 hover:bg-amber-500/10 rounded-md transition-colors"
+              >
+                Admin
+              </Link>
+            </PlatformAdminGuard>
           </nav>
           {user ? (
             <div className="flex items-center gap-3 relative" ref={dropdownRef}>

--- a/apps/web/src/app/(inside)/admin/_components/access-denied.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/access-denied.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Lock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useUser } from "@/contexts/UserContext";
+
+export function AccessDenied() {
+  const { user } = useUser();
+
+  return (
+    <div className="relative flex min-h-[calc(100vh-200px)] items-center justify-center overflow-hidden p-6">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-40 left-1/4 h-72 w-72 rounded-full bg-red-500/20 blur-3xl"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -bottom-40 right-1/4 h-72 w-72 rounded-full bg-amber-500/15 blur-3xl"
+      />
+      <div className="relative max-w-md rounded-2xl border border-slate-700/60 bg-slate-900/80 p-8 text-center backdrop-blur">
+        <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-2xl border border-red-500/30 bg-red-500/10 text-red-400">
+          <Lock className="h-6 w-6" />
+        </div>
+        <h1 className="text-xl font-semibold text-white">Acesso restrito</h1>
+        <p className="mt-2 text-sm leading-relaxed text-slate-400">
+          Você não tem permissão de{" "}
+          <span className="font-semibold text-amber-400">Platform Admin</span>{" "}
+          para acessar esta área. Se você acredita que isso é um engano,
+          procure um administrador da plataforma.
+        </p>
+        {user?.email && (
+          <div className="mt-5 rounded-md border border-slate-700/60 bg-slate-900/60 px-3 py-2 text-xs text-slate-400">
+            Conectado como{" "}
+            <span className="font-medium text-white">{user.email}</span>
+          </div>
+        )}
+        <div className="mt-6 flex justify-center">
+          <Button asChild variant="outline">
+            <Link href="/explore">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Voltar para o app
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/_components/admin-breadcrumbs.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-breadcrumbs.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { Fragment } from "react";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface AdminBreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export function AdminBreadcrumbs({ items }: AdminBreadcrumbsProps) {
+  return (
+    <nav aria-label="Caminho" className="flex items-center gap-1.5 text-sm text-slate-400">
+      {items.map((item, idx) => {
+        const isLast = idx === items.length - 1;
+        return (
+          <Fragment key={`${idx}-${item.label}`}>
+            {idx > 0 && <ChevronRight className="h-3.5 w-3.5 text-slate-600" />}
+            {item.href && !isLast ? (
+              <Link
+                href={item.href}
+                className="rounded px-1 py-0.5 hover:text-white"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className={isLast ? "text-white font-medium" : undefined}>
+                {item.label}
+              </span>
+            )}
+          </Fragment>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/_components/admin-route-breadcrumbs.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-route-breadcrumbs.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useGetV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { AdminTopbar } from "./admin-topbar";
+import type { BreadcrumbItem } from "./admin-breadcrumbs";
+
+const segmentLabels: Record<string, string> = {
+  admin: "Admin",
+  organizations: "Organizações",
+  users: "Usuários",
+  members: "Membros",
+  domains: "Domínios",
+  settings: "Configurações",
+};
+
+interface SegmentInfo {
+  segment: string;
+  fullPath: string;
+}
+
+function buildSegments(pathname: string): SegmentInfo[] {
+  const parts = pathname.split("/").filter(Boolean);
+  const out: SegmentInfo[] = [];
+  let cumulative = "";
+  for (const part of parts) {
+    cumulative += `/${part}`;
+    out.push({ segment: part, fullPath: cumulative });
+  }
+  return out;
+}
+
+/**
+ * Builds breadcrumbs from the current pathname for the /admin area.
+ * When an org id is in the path, fetches its name to render in place of the id.
+ */
+export function AdminRouteBreadcrumbs() {
+  const pathname = usePathname() ?? "";
+  const segments = buildSegments(pathname);
+
+  const orgIndex = segments.findIndex(
+    (s, idx) => idx >= 2 && segments[idx - 1]?.segment === "organizations",
+  );
+  const orgIdSegment = orgIndex >= 0 ? segments[orgIndex] : null;
+
+  const orgQuery = useGetV1OrganizationsId(orgIdSegment?.segment ?? "", {
+    query: { enabled: !!orgIdSegment?.segment },
+  });
+  const orgName = orgQuery.data?.data?.name;
+
+  const items: BreadcrumbItem[] = segments.map(({ segment, fullPath }, idx) => {
+    if (orgIdSegment && idx === orgIndex) {
+      return {
+        label: orgName ?? segment.slice(0, 8),
+        href: fullPath,
+      };
+    }
+    const label = segmentLabels[segment] ?? segment;
+    return { label, href: fullPath };
+  });
+
+  return <AdminTopbar breadcrumbs={items} />;
+}

--- a/apps/web/src/app/(inside)/admin/_components/admin-route-breadcrumbs.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-route-breadcrumbs.tsx
@@ -30,11 +30,17 @@ function buildSegments(pathname: string): SegmentInfo[] {
   return out;
 }
 
+interface AdminRouteBreadcrumbsProps {
+  onOpenMobileSidebar?: () => void;
+}
+
 /**
  * Builds breadcrumbs from the current pathname for the /admin area.
  * When an org id is in the path, fetches its name to render in place of the id.
  */
-export function AdminRouteBreadcrumbs() {
+export function AdminRouteBreadcrumbs({
+  onOpenMobileSidebar,
+}: AdminRouteBreadcrumbsProps) {
   const pathname = usePathname() ?? "";
   const segments = buildSegments(pathname);
 
@@ -59,5 +65,7 @@ export function AdminRouteBreadcrumbs() {
     return { label, href: fullPath };
   });
 
-  return <AdminTopbar breadcrumbs={items} />;
+  return (
+    <AdminTopbar breadcrumbs={items} onOpenMobileSidebar={onOpenMobileSidebar} />
+  );
 }

--- a/apps/web/src/app/(inside)/admin/_components/admin-sidebar.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-sidebar.tsx
@@ -3,7 +3,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Building2, LogOut, ShieldCheck, Users } from "lucide-react";
+import { Building2, LogOut, ShieldCheck, Users, X } from "lucide-react";
+import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useUser } from "@/contexts/UserContext";
 import { AvatarSquare } from "@/components/admin/avatar-square";
@@ -19,13 +20,36 @@ const navItems: NavItem[] = [
   { href: "/admin/users", label: "Usuários", icon: Users },
 ];
 
-export function AdminSidebar() {
-  const pathname = usePathname() ?? "";
-  const { user, logout } = useUser();
+interface AdminSidebarProps {
+  /**
+   * Whether the mobile drawer overlay is visible.
+   * Desktop sidebar (`lg+`) is always visible regardless of this flag.
+   */
+  mobileOpen?: boolean;
+  /** Called when the user dismisses the mobile drawer. */
+  onCloseMobile?: () => void;
+}
 
+interface SidebarContentProps {
+  pathname: string;
+  user: ReturnType<typeof useUser>["user"];
+  logout: ReturnType<typeof useUser>["logout"];
+  onNavigate?: () => void;
+}
+
+function SidebarContent({
+  pathname,
+  user,
+  logout,
+  onNavigate,
+}: SidebarContentProps) {
   return (
-    <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-6 border-r border-slate-800/80 bg-slate-950/60 p-4">
-      <Link href="/admin" className="flex items-center gap-2 px-2 py-1.5">
+    <>
+      <Link
+        href="/admin"
+        onClick={onNavigate}
+        className="flex items-center gap-2 px-2 py-1.5"
+      >
         <Image
           src="/header-logo.png"
           alt="TACO"
@@ -51,6 +75,7 @@ export function AdminSidebar() {
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={onNavigate}
                 className={cn(
                   "group flex items-center gap-3 rounded-md px-2.5 py-2 text-sm transition-colors",
                   active
@@ -61,7 +86,9 @@ export function AdminSidebar() {
                 <Icon
                   className={cn(
                     "h-4 w-4",
-                    active ? "text-amber-300" : "text-slate-400 group-hover:text-slate-200",
+                    active
+                      ? "text-amber-300"
+                      : "text-slate-400 group-hover:text-slate-200",
                   )}
                 />
                 <span>{item.label}</span>
@@ -94,6 +121,64 @@ export function AdminSidebar() {
           <LogOut className="h-4 w-4" />
         </button>
       </div>
-    </aside>
+    </>
+  );
+}
+
+export function AdminSidebar({
+  mobileOpen = false,
+  onCloseMobile,
+}: AdminSidebarProps) {
+  const pathname = usePathname() ?? "";
+  const { user, logout } = useUser();
+
+  // Close drawer with Escape and lock background scroll while it is open.
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onCloseMobile?.();
+    };
+    window.addEventListener("keydown", handleKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [mobileOpen, onCloseMobile]);
+
+  return (
+    <>
+      <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-6 border-r border-slate-800/80 bg-slate-950/60 p-4">
+        <SidebarContent pathname={pathname} user={user} logout={logout} />
+      </aside>
+
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true">
+          <button
+            type="button"
+            aria-label="Fechar menu"
+            onClick={onCloseMobile}
+            className="absolute inset-0 bg-slate-950/70 backdrop-blur-sm"
+          />
+          <aside className="relative flex h-full w-72 max-w-[85%] flex-col gap-6 border-r border-slate-800/80 bg-slate-950 p-4">
+            <button
+              type="button"
+              onClick={onCloseMobile}
+              className="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+              aria-label="Fechar menu"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <SidebarContent
+              pathname={pathname}
+              user={user}
+              logout={logout}
+              onNavigate={onCloseMobile}
+            />
+          </aside>
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/app/(inside)/admin/_components/admin-sidebar.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-sidebar.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Building2, LogOut, ShieldCheck, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useUser } from "@/contexts/UserContext";
+import { AvatarSquare } from "@/components/admin/avatar-square";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: typeof Building2;
+}
+
+const navItems: NavItem[] = [
+  { href: "/admin/organizations", label: "Organizações", icon: Building2 },
+  { href: "/admin/users", label: "Usuários", icon: Users },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname() ?? "";
+  const { user, logout } = useUser();
+
+  return (
+    <aside className="hidden lg:flex w-64 shrink-0 flex-col gap-6 border-r border-slate-800/80 bg-slate-950/60 p-4">
+      <Link href="/admin" className="flex items-center gap-2 px-2 py-1.5">
+        <Image
+          src="/header-logo.png"
+          alt="TACO"
+          width={84}
+          height={28}
+          priority
+          className="h-7 w-auto"
+        />
+        <span className="rounded-md border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-300">
+          Admin
+        </span>
+      </Link>
+
+      <nav className="flex flex-col gap-2">
+        <div className="px-2 text-[11px] font-medium uppercase tracking-wider text-slate-500">
+          Plataforma
+        </div>
+        <div className="flex flex-col gap-1">
+          {navItems.map((item) => {
+            const active = pathname.startsWith(item.href);
+            const Icon = item.icon;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "group flex items-center gap-3 rounded-md px-2.5 py-2 text-sm transition-colors",
+                  active
+                    ? "bg-amber-500/10 text-amber-200"
+                    : "text-slate-300 hover:bg-slate-800/60 hover:text-white",
+                )}
+              >
+                <Icon
+                  className={cn(
+                    "h-4 w-4",
+                    active ? "text-amber-300" : "text-slate-400 group-hover:text-slate-200",
+                  )}
+                />
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
+
+      <div className="mt-auto flex items-center gap-3 rounded-lg border border-slate-800/80 bg-slate-900/60 p-3">
+        <AvatarSquare name={user?.name ?? "Admin"} src={user?.image} size="sm" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-medium text-white">
+            {user?.name ?? "Admin"}
+          </div>
+          <div className="flex items-center gap-1 text-[10px] text-slate-400">
+            <ShieldCheck className="h-3 w-3 text-amber-300" />
+            Platform Admin
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void logout();
+          }}
+          className="text-slate-400 hover:text-white"
+          title="Sair"
+          aria-label="Sair"
+        >
+          <LogOut className="h-4 w-4" />
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/_components/admin-topbar.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-topbar.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import { Bell, CircleHelp, Search } from "lucide-react";
+import { Bell, CircleHelp, Menu, Search } from "lucide-react";
 import type { BreadcrumbItem } from "./admin-breadcrumbs";
 import { AdminBreadcrumbs } from "./admin-breadcrumbs";
 
 interface AdminTopbarProps {
   breadcrumbs: BreadcrumbItem[];
+  /** Called when the user opens the mobile sidebar via the hamburger button. */
+  onOpenMobileSidebar?: () => void;
 }
 
-export function AdminTopbar({ breadcrumbs }: AdminTopbarProps) {
+export function AdminTopbar({
+  breadcrumbs,
+  onOpenMobileSidebar,
+}: AdminTopbarProps) {
   return (
     <div className="flex h-14 items-center gap-3 border-b border-slate-800/80 bg-slate-950/40 px-4 backdrop-blur lg:px-6">
+      <button
+        type="button"
+        onClick={onOpenMobileSidebar}
+        className="flex h-8 w-8 items-center justify-center rounded-md text-slate-300 hover:bg-slate-800/60 hover:text-white lg:hidden"
+        title="Abrir menu"
+        aria-label="Abrir menu"
+      >
+        <Menu className="h-4 w-4" />
+      </button>
       <AdminBreadcrumbs items={breadcrumbs} />
       <div className="flex-1" />
       <div className="flex items-center gap-1">

--- a/apps/web/src/app/(inside)/admin/_components/admin-topbar.tsx
+++ b/apps/web/src/app/(inside)/admin/_components/admin-topbar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Bell, CircleHelp, Search } from "lucide-react";
+import type { BreadcrumbItem } from "./admin-breadcrumbs";
+import { AdminBreadcrumbs } from "./admin-breadcrumbs";
+
+interface AdminTopbarProps {
+  breadcrumbs: BreadcrumbItem[];
+}
+
+export function AdminTopbar({ breadcrumbs }: AdminTopbarProps) {
+  return (
+    <div className="flex h-14 items-center gap-3 border-b border-slate-800/80 bg-slate-950/40 px-4 backdrop-blur lg:px-6">
+      <AdminBreadcrumbs items={breadcrumbs} />
+      <div className="flex-1" />
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+          title="Buscar"
+          aria-label="Buscar"
+        >
+          <Search className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+          title="Notificações"
+          aria-label="Notificações"
+        >
+          <Bell className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+          title="Ajuda"
+          aria-label="Ajuda"
+        >
+          <CircleHelp className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/layout.tsx
+++ b/apps/web/src/app/(inside)/admin/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useUser } from "@/contexts/UserContext";
 import { AdminSidebar } from "./_components/admin-sidebar";
@@ -12,6 +13,7 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   const { user, isLoading } = useUser();
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   if (isLoading) {
     return (
@@ -27,9 +29,14 @@ export default function AdminLayout({
 
   return (
     <div className="flex min-h-[calc(100vh-65px)] w-full bg-slate-950/40">
-      <AdminSidebar />
+      <AdminSidebar
+        mobileOpen={mobileSidebarOpen}
+        onCloseMobile={() => setMobileSidebarOpen(false)}
+      />
       <div className="flex min-w-0 flex-1 flex-col">
-        <AdminRouteBreadcrumbs />
+        <AdminRouteBreadcrumbs
+          onOpenMobileSidebar={() => setMobileSidebarOpen(true)}
+        />
         <main className="flex-1 px-4 py-6 lg:px-8 lg:py-8">{children}</main>
       </div>
     </div>

--- a/apps/web/src/app/(inside)/admin/layout.tsx
+++ b/apps/web/src/app/(inside)/admin/layout.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useUser } from "@/contexts/UserContext";
+import { AdminSidebar } from "./_components/admin-sidebar";
+import { AdminRouteBreadcrumbs } from "./_components/admin-route-breadcrumbs";
+import { AccessDenied } from "./_components/access-denied";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, isLoading } = useUser();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-amber-400" />
+      </div>
+    );
+  }
+
+  if (!user?.isPlatformAdmin) {
+    return <AccessDenied />;
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-65px)] w-full bg-slate-950/40">
+      <AdminSidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <AdminRouteBreadcrumbs />
+        <main className="flex-1 px-4 py-6 lg:px-8 lg:py-8">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/_components/org-header.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/_components/org-header.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  AtSign,
+  Calendar,
+  CirclePause,
+  CirclePlay,
+  GraduationCap,
+  Pencil,
+  Users,
+} from "lucide-react";
+import { toast } from "sonner";
+import { AvatarSquare } from "@/components/admin/avatar-square";
+import { StatusPill } from "@/components/admin/status-pill";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { usePatchV1OrganizationsIdActive } from "@/kubb/hooks/organizationsHooks/usePatchV1OrganizationsIdActive";
+import { getV1OrganizationsIdQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { EditOrganizationDialog } from "../../_components/edit-organization-dialog";
+
+interface OrgHeaderProps {
+  org: {
+    id: string;
+    name: string;
+    slug: string;
+    logo: string | null;
+    isActive: boolean;
+    createdAt: string;
+    memberCount: number;
+    classroomCount: number;
+  };
+}
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return dateFormatter.format(d);
+}
+
+export function OrgHeader({ org }: OrgHeaderProps) {
+  const queryClient = useQueryClient();
+  const [editOpen, setEditOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const toggleActive = usePatchV1OrganizationsIdActive({
+    mutation: {
+      onSuccess: () => {
+        toast.success(
+          org.isActive ? "Organização desativada" : "Organização reativada",
+        );
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/organizations/:id"
+            );
+          },
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(org.id),
+        });
+        setConfirmOpen(false);
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao atualizar status",
+        );
+      },
+    },
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex items-start gap-4">
+          <AvatarSquare name={org.name} src={org.logo} size="lg" />
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-semibold text-white">{org.name}</h1>
+              <StatusPill active={org.isActive} />
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-400">
+              <span className="inline-flex items-center gap-1.5">
+                <AtSign className="h-3 w-3" />
+                {org.slug}
+              </span>
+              <span className="text-slate-600">·</span>
+              <span className="inline-flex items-center gap-1.5">
+                <Users className="h-3 w-3" />
+                {org.memberCount} {org.memberCount === 1 ? "membro" : "membros"}
+              </span>
+              <span className="text-slate-600">·</span>
+              <span className="inline-flex items-center gap-1.5">
+                <GraduationCap className="h-3 w-3" />
+                {org.classroomCount}{" "}
+                {org.classroomCount === 1 ? "turma" : "turmas"}
+              </span>
+              <span className="text-slate-600">·</span>
+              <span className="inline-flex items-center gap-1.5">
+                <Calendar className="h-3 w-3" />
+                Criada em {formatDate(org.createdAt)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setEditOpen(true)}
+          >
+            <Pencil className="h-4 w-4" />
+            Editar
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setConfirmOpen(true)}
+            className="border-red-500/30 text-red-300 hover:bg-red-500/10 hover:text-red-200"
+          >
+            {org.isActive ? (
+              <CirclePause className="h-4 w-4" />
+            ) : (
+              <CirclePlay className="h-4 w-4" />
+            )}
+            {org.isActive ? "Desativar" : "Reativar"}
+          </Button>
+        </div>
+      </div>
+
+      <EditOrganizationDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        org={editOpen ? org : null}
+      />
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent className="bg-slate-900 border-slate-700 text-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {org.isActive
+                ? "Desativar organização?"
+                : "Reativar organização?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-400">
+              {org.isActive
+                ? "Membros perderão acesso imediatamente. Os dados são preservados e você pode reativar quando quiser."
+                : "Membros recuperarão o acesso imediatamente."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={toggleActive.isPending}>
+              Cancelar
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={toggleActive.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                toggleActive.mutate({
+                  id: org.id,
+                  data: { isActive: !org.isActive },
+                });
+              }}
+              className={
+                org.isActive
+                  ? "bg-red-500 text-white hover:bg-red-400"
+                  : "bg-amber-500 text-slate-900 hover:bg-amber-400"
+              }
+            >
+              {org.isActive ? "Sim, desativar" : "Sim, reativar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/_components/org-tabs-nav.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/_components/org-tabs-nav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Globe, Settings, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface OrgTabsNavProps {
+  orgId: string;
+}
+
+const tabs = [
+  { key: "members", label: "Membros", icon: Users },
+  { key: "domains", label: "Domínios", icon: Globe },
+  { key: "settings", label: "Configurações", icon: Settings },
+] as const;
+
+export function OrgTabsNav({ orgId }: OrgTabsNavProps) {
+  const pathname = usePathname() ?? "";
+
+  return (
+    <div className="flex items-center gap-1 border-b border-slate-700/60">
+      {tabs.map((tab) => {
+        const href = `/admin/organizations/${orgId}/${tab.key}`;
+        const active = pathname.startsWith(href);
+        const Icon = tab.icon;
+        return (
+          <Link
+            key={tab.key}
+            href={href}
+            className={cn(
+              "-mb-px flex items-center gap-2 border-b-2 px-3 py-2.5 text-sm transition-colors",
+              active
+                ? "border-amber-400 text-white"
+                : "border-transparent text-slate-400 hover:text-white",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/domains/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/domains/page.tsx
@@ -1,0 +1,16 @@
+import { Globe } from "lucide-react";
+import { EmptyState } from "@/components/admin/empty-state";
+
+/**
+ * Placeholder owned by Agent D (domains tab).
+ * Lives here so the Domínios tab does not 404 while the real page is wired.
+ */
+export default function DomainsTabPlaceholderPage() {
+  return (
+    <EmptyState
+      icon={Globe}
+      title="Em construção"
+      body="A aba de domínios será entregue em breve pelo agente responsável."
+    />
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/layout.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/layout.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { useGetV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { Button } from "@/components/ui/button";
+import { OrgHeader } from "./_components/org-header";
+import { OrgTabsNav } from "./_components/org-tabs-nav";
+
+export default function OrganizationDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const params = useParams<{ id: string }>();
+  const id = params?.id ?? "";
+
+  const { data, isLoading, error } = useGetV1OrganizationsId(id, {
+    query: { enabled: id.length > 0 },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-amber-400" />
+      </div>
+    );
+  }
+
+  if (error || !data?.data) {
+    return (
+      <div className="space-y-4">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/admin/organizations">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Voltar
+          </Link>
+        </Button>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+          Não foi possível carregar a organização.{" "}
+          {error instanceof Error ? error.message : ""}
+        </div>
+      </div>
+    );
+  }
+
+  const org = data.data;
+
+  return (
+    <div className="space-y-6">
+      <OrgHeader org={org} />
+      <OrgTabsNav orgId={org.id} />
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
@@ -1,0 +1,16 @@
+import { Users } from "lucide-react";
+import { EmptyState } from "@/components/admin/empty-state";
+
+/**
+ * Placeholder owned by Agent B (members tab).
+ * Lives here so the Membros tab does not 404 while the real page is wired.
+ */
+export default function MembersTabPlaceholderPage() {
+  return (
+    <EmptyState
+      icon={Users}
+      title="Em construção"
+      body="A aba de membros será entregue em breve pelo agente responsável."
+    />
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/page.tsx
@@ -1,18 +1,11 @@
-"use client";
+import { redirect } from "next/navigation";
 
-import { useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+interface OrganizationDetailIndexPageProps {
+  params: { id: string };
+}
 
-export default function OrganizationDetailIndexPage() {
-  const router = useRouter();
-  const params = useParams<{ id: string }>();
-  const id = params?.id;
-
-  useEffect(() => {
-    if (id) {
-      router.replace(`/admin/organizations/${id}/members`);
-    }
-  }, [id, router]);
-
-  return null;
+export default function OrganizationDetailIndexPage({
+  params,
+}: OrganizationDetailIndexPageProps) {
+  redirect(`/admin/organizations/${params.id}/members`);
 }

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+export default function OrganizationDetailIndexPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+
+  useEffect(() => {
+    if (id) {
+      router.replace(`/admin/organizations/${id}/members`);
+    }
+  }, [id, router]);
+
+  return null;
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/settings/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/settings/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { CirclePause, CirclePlay, Loader2, Save } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  useGetV1OrganizationsId,
+  getV1OrganizationsIdQueryKey,
+} from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { usePutV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/usePutV1OrganizationsId";
+import { usePatchV1OrganizationsIdActive } from "@/kubb/hooks/organizationsHooks/usePatchV1OrganizationsIdActive";
+import {
+  OrganizationFormFields,
+  organizationFormSchema,
+  type OrganizationFormValues,
+} from "../../_components/organization-form-fields";
+
+export default function OrganizationSettingsPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id ?? "";
+  const queryClient = useQueryClient();
+
+  const { data } = useGetV1OrganizationsId(id, {
+    query: { enabled: id.length > 0 },
+  });
+  const org = data?.data;
+
+  const form = useForm<OrganizationFormValues>({
+    resolver: zodResolver(organizationFormSchema),
+    defaultValues: { name: "", slug: "", logo: "" },
+  });
+
+  useEffect(() => {
+    if (org) {
+      form.reset({
+        name: org.name,
+        slug: org.slug,
+        logo: org.logo ?? "",
+      });
+    }
+  }, [org, form]);
+
+  const updateMutation = usePutV1OrganizationsId({
+    mutation: {
+      onSuccess: (response) => {
+        toast.success(`Organização "${response.data.name}" atualizada`);
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/organizations/:id"
+            );
+          },
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(id),
+        });
+        form.reset({
+          name: response.data.name,
+          slug: response.data.slug,
+          logo: response.data.logo ?? "",
+        });
+      },
+      onError: (err) => {
+        const status = (err as { status?: number } | undefined)?.status;
+        toast.error(
+          status === 409
+            ? "Slug já está em uso"
+            : err instanceof Error
+              ? err.message
+              : "Erro ao salvar",
+        );
+      },
+    },
+  });
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const toggleActive = usePatchV1OrganizationsIdActive({
+    mutation: {
+      onSuccess: () => {
+        toast.success(
+          org?.isActive ? "Organização desativada" : "Organização reativada",
+        );
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/organizations/:id"
+            );
+          },
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(id),
+        });
+        setConfirmOpen(false);
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao atualizar status",
+        );
+      },
+    },
+  });
+
+  if (!org) return null;
+
+  const onSubmit = (values: OrganizationFormValues) => {
+    updateMutation.mutate({
+      id,
+      data: {
+        name: values.name.trim(),
+        slug: values.slug.trim(),
+        logo: values.logo ? values.logo : null,
+      },
+    });
+  };
+
+  return (
+    <div className="grid max-w-3xl gap-6">
+      <Card className="bg-slate-900/60 border-slate-700/60 text-white">
+        <CardHeader>
+          <CardTitle className="text-base">Detalhes da organização</CardTitle>
+          <p className="text-xs text-slate-400">
+            A identidade pública da organização. Membros verão estes dados na
+            navbar e nos links de turmas.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
+            <OrganizationFormFields form={form} />
+            <div className="flex justify-end gap-2 border-t border-slate-700/60 pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() =>
+                  form.reset({
+                    name: org.name,
+                    slug: org.slug,
+                    logo: org.logo ?? "",
+                  })
+                }
+                disabled={!form.formState.isDirty || updateMutation.isPending}
+              >
+                Descartar
+              </Button>
+              <Button
+                type="submit"
+                disabled={!form.formState.isDirty || updateMutation.isPending}
+                className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+              >
+                {updateMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                Salvar alterações
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card className="bg-slate-900/60 border-red-500/25 text-white">
+        <CardHeader>
+          <CardTitle className="text-base">Zona de risco</CardTitle>
+          <p className="text-xs text-slate-400">
+            Desativar congela o acesso de membros e oculta as turmas das buscas.
+            Os dados são preservados e podem ser reativados a qualquer momento.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-red-500/20 bg-red-500/5 p-4">
+            <div>
+              <div className="text-sm font-medium text-white">
+                {org.isActive
+                  ? "Desativar organização"
+                  : "Reativar organização"}
+              </div>
+              <div className="mt-0.5 text-xs text-slate-400">
+                {org.isActive
+                  ? "Membros perderão acesso imediatamente."
+                  : "Membros recuperarão o acesso imediatamente."}
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirmOpen(true)}
+              className="border-red-500/30 text-red-300 hover:bg-red-500/10 hover:text-red-200"
+            >
+              {org.isActive ? (
+                <CirclePause className="h-4 w-4" />
+              ) : (
+                <CirclePlay className="h-4 w-4" />
+              )}
+              {org.isActive ? "Desativar" : "Reativar"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent className="bg-slate-900 border-slate-700 text-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {org.isActive
+                ? "Desativar organização?"
+                : "Reativar organização?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-400">
+              {org.isActive
+                ? `Membros de "${org.name}" perderão acesso imediatamente. Você pode reativar quando quiser.`
+                : `Membros de "${org.name}" recuperarão o acesso imediatamente.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={toggleActive.isPending}>
+              Cancelar
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={toggleActive.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                toggleActive.mutate({
+                  id,
+                  data: { isActive: !org.isActive },
+                });
+              }}
+              className={
+                org.isActive
+                  ? "bg-red-500 text-white hover:bg-red-400"
+                  : "bg-amber-500 text-slate-900 hover:bg-amber-400"
+              }
+            >
+              {org.isActive ? "Sim, desativar" : "Sim, reativar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/_components/create-organization-dialog.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/_components/create-organization-dialog.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plus } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { usePostV1Organizations } from "@/kubb/hooks/organizationsHooks/usePostV1Organizations";
+import {
+  OrganizationFormFields,
+  organizationFormSchema,
+  type OrganizationFormValues,
+} from "./organization-form-fields";
+
+interface CreateOrganizationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CreateOrganizationDialog({
+  open,
+  onOpenChange,
+}: CreateOrganizationDialogProps) {
+  const queryClient = useQueryClient();
+
+  const form = useForm<OrganizationFormValues>({
+    resolver: zodResolver(organizationFormSchema),
+    defaultValues: { name: "", slug: "", logo: "" },
+  });
+
+  useEffect(() => {
+    if (open) form.reset({ name: "", slug: "", logo: "" });
+  }, [open, form]);
+
+  const mutation = usePostV1Organizations({
+    mutation: {
+      onSuccess: (response) => {
+        toast.success(`Organização "${response.data.name}" criada`);
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return first?.url === "/v1/organizations/";
+          },
+        });
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        const status = (err as { status?: number } | undefined)?.status;
+        const message =
+          err instanceof Error ? err.message : "Erro ao criar organização";
+        toast.error(status === 409 ? "Slug já está em uso" : message);
+      },
+    },
+  });
+
+  const onSubmit = (values: OrganizationFormValues) => {
+    mutation.mutate({
+      data: {
+        name: values.name.trim(),
+        slug: values.slug.trim(),
+        ...(values.logo ? { logo: values.logo } : {}),
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Nova organização</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Crie uma nova organização na plataforma TACO.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <OrganizationFormFields form={form} autoSlug />
+          <DialogFooter className="gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={mutation.isPending}
+              className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+            >
+              {mutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              Criar organização
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/_components/edit-organization-dialog.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/_components/edit-organization-dialog.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, Save } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { usePutV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/usePutV1OrganizationsId";
+import { getV1OrganizationsIdQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import {
+  OrganizationFormFields,
+  organizationFormSchema,
+  type OrganizationFormValues,
+} from "./organization-form-fields";
+
+interface EditableOrg {
+  id: string;
+  name: string;
+  slug: string;
+  logo: string | null;
+}
+
+interface EditOrganizationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  org: EditableOrg | null;
+}
+
+export function EditOrganizationDialog({
+  open,
+  onOpenChange,
+  org,
+}: EditOrganizationDialogProps) {
+  const queryClient = useQueryClient();
+
+  const form = useForm<OrganizationFormValues>({
+    resolver: zodResolver(organizationFormSchema),
+    defaultValues: { name: "", slug: "", logo: "" },
+  });
+
+  useEffect(() => {
+    if (open && org) {
+      form.reset({
+        name: org.name,
+        slug: org.slug,
+        logo: org.logo ?? "",
+      });
+    }
+  }, [open, org, form]);
+
+  const mutation = usePutV1OrganizationsId({
+    mutation: {
+      onSuccess: (response) => {
+        toast.success(`Organização "${response.data.name}" atualizada`);
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/organizations/:id"
+            );
+          },
+        });
+        if (org) {
+          void queryClient.invalidateQueries({
+            queryKey: getV1OrganizationsIdQueryKey(org.id),
+          });
+        }
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        const status = (err as { status?: number } | undefined)?.status;
+        const message =
+          err instanceof Error ? err.message : "Erro ao atualizar organização";
+        toast.error(status === 409 ? "Slug já está em uso" : message);
+      },
+    },
+  });
+
+  const onSubmit = (values: OrganizationFormValues) => {
+    if (!org) return;
+    mutation.mutate({
+      id: org.id,
+      data: {
+        name: values.name.trim(),
+        slug: values.slug.trim(),
+        logo: values.logo ? values.logo : null,
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Editar organização</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Atualize a identidade pública desta organização.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <OrganizationFormFields form={form} />
+          <DialogFooter className="gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={mutation.isPending}
+              className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+            >
+              {mutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              Salvar alterações
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/_components/organization-form-fields.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/_components/organization-form-fields.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { z } from "zod";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export const organizationFormSchema = z.object({
+  name: z
+    .string()
+    .min(2, "Nome deve ter pelo menos 2 caracteres")
+    .max(120, "Nome deve ter no máximo 120 caracteres"),
+  slug: z
+    .string()
+    .min(1, "Slug é obrigatório")
+    .max(60, "Slug deve ter no máximo 60 caracteres")
+    .regex(
+      /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/,
+      "Use apenas letras minúsculas, números e hífens",
+    ),
+  logo: z
+    .string()
+    .max(500, "URL muito longa")
+    .url("URL inválida")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type OrganizationFormValues = z.infer<typeof organizationFormSchema>;
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+interface OrganizationFormFieldsProps {
+  form: UseFormReturn<OrganizationFormValues>;
+  /** When true, slug is auto-generated from name on every name change while slug stays untouched. */
+  autoSlug?: boolean;
+}
+
+export function OrganizationFormFields({
+  form,
+  autoSlug = false,
+}: OrganizationFormFieldsProps) {
+  const {
+    register,
+    formState: { errors, dirtyFields },
+    watch,
+    setValue,
+  } = form;
+
+  const name = watch("name");
+  const slugTouched = !!dirtyFields.slug;
+
+  useEffect(() => {
+    if (!autoSlug || slugTouched) return;
+    setValue("slug", slugify(name ?? ""), {
+      shouldDirty: false,
+      shouldValidate: true,
+    });
+  }, [autoSlug, slugTouched, name, setValue]);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="org-name" className="text-slate-300">
+          Nome
+        </Label>
+        <Input
+          id="org-name"
+          placeholder="ex.: Instituto Federal de São Paulo"
+          autoFocus
+          {...register("name")}
+          className="bg-slate-900 border-slate-700 text-white"
+        />
+        {errors.name && (
+          <p className="text-xs text-red-400">{errors.name.message}</p>
+        )}
+        <p className="text-[11px] text-slate-500">
+          Nome de exibição para os membros. Use o nome oficial da instituição.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="org-slug" className="text-slate-300">
+          Slug
+        </Label>
+        <div className="flex overflow-hidden rounded-md border border-slate-700 bg-slate-900">
+          <span className="border-r border-slate-700 bg-slate-900/80 px-3 py-2 text-xs text-slate-500">
+            taco.dev/o/
+          </span>
+          <input
+            id="org-slug"
+            type="text"
+            placeholder="ifsp"
+            {...register("slug", {
+              setValueAs: (v: string) => slugify(v ?? ""),
+            })}
+            className="w-full bg-transparent px-3 py-2 text-sm text-white outline-none"
+          />
+        </div>
+        {errors.slug && (
+          <p className="text-xs text-red-400">{errors.slug.message}</p>
+        )}
+        <p className="text-[11px] text-slate-500">
+          Apenas letras minúsculas, números e hífens. Usado em URLs.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="org-logo" className="text-slate-300">
+          URL do logo{" "}
+          <span className="text-slate-500 font-normal">· opcional</span>
+        </Label>
+        <Input
+          id="org-logo"
+          placeholder="https://exemplo.edu.br/logo.png"
+          {...register("logo")}
+          className="bg-slate-900 border-slate-700 text-white"
+        />
+        {errors.logo && (
+          <p className="text-xs text-red-400">{errors.logo.message}</p>
+        )}
+        <p className="text-[11px] text-slate-500">
+          PNG ou SVG quadrado. Caímos no avatar com iniciais quando vazio.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/_components/organizations-table.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/_components/organizations-table.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import Link from "next/link";
+import { CirclePause, CirclePlay, Eye, Pencil } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { OrgCell } from "@/components/admin/org-cell";
+import { StatusPill } from "@/components/admin/status-pill";
+
+export interface OrganizationRow {
+  id: string;
+  name: string;
+  slug: string;
+  logo: string | null;
+  isActive: boolean;
+  createdAt: string;
+  memberCount: number;
+  classroomCount: number;
+}
+
+interface OrganizationsTableProps {
+  rows: OrganizationRow[];
+  isLoading: boolean;
+  onEdit: (org: OrganizationRow) => void;
+  onToggleActive: (org: OrganizationRow) => void;
+  togglingId?: string;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return dateFormatter.format(d);
+}
+
+export function OrganizationsTable({
+  rows,
+  isLoading,
+  onEdit,
+  onToggleActive,
+  togglingId,
+}: OrganizationsTableProps) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="border-slate-700/60 hover:bg-transparent">
+          <TableHead className="text-slate-400">Organização</TableHead>
+          <TableHead className="text-slate-400">Status</TableHead>
+          <TableHead className="text-right text-slate-400">Membros</TableHead>
+          <TableHead className="text-right text-slate-400">Turmas</TableHead>
+          <TableHead className="text-slate-400">Criada em</TableHead>
+          <TableHead className="text-right text-slate-400">Ações</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {isLoading
+          ? Array.from({ length: 5 }).map((_, i) => (
+              <TableRow key={`sk-${i}`} className="border-slate-700/60">
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-10 w-10 rounded-lg bg-slate-800" />
+                    <div className="space-y-1.5">
+                      <Skeleton className="h-3 w-40 bg-slate-800" />
+                      <Skeleton className="h-2.5 w-20 bg-slate-800" />
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-5 w-16 bg-slate-800" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-3 w-8 bg-slate-800" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-3 w-8 bg-slate-800" />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-3 w-24 bg-slate-800" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-7 w-20 bg-slate-800" />
+                </TableCell>
+              </TableRow>
+            ))
+          : rows.map((org) => (
+              <TableRow
+                key={org.id}
+                className="border-slate-700/60 hover:bg-slate-800/40"
+              >
+                <TableCell className="py-3">
+                  <Link
+                    href={`/admin/organizations/${org.id}`}
+                    className="block"
+                  >
+                    <OrgCell
+                      name={org.name}
+                      slug={org.slug}
+                      logo={org.logo}
+                    />
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <StatusPill active={org.isActive} />
+                </TableCell>
+                <TableCell className="text-right text-sm font-medium text-white">
+                  {org.memberCount}
+                </TableCell>
+                <TableCell className="text-right text-sm font-medium text-white">
+                  {org.classroomCount}
+                </TableCell>
+                <TableCell className="text-xs text-slate-400">
+                  {formatDate(org.createdAt)}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <Link
+                      href={`/admin/organizations/${org.id}`}
+                      title="Ver"
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Link>
+                    <button
+                      type="button"
+                      title="Editar"
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                      onClick={() => onEdit(org)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      title={org.isActive ? "Desativar" : "Reativar"}
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white disabled:opacity-50"
+                      onClick={() => onToggleActive(org)}
+                      disabled={togglingId === org.id}
+                    >
+                      {org.isActive ? (
+                        <CirclePause className="h-4 w-4" />
+                      ) : (
+                        <CirclePlay className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Building2,
+  Plus,
+  RotateCw,
+  Search,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useGetV1Organizations } from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
+import { usePatchV1OrganizationsIdActive } from "@/kubb/hooks/organizationsHooks/usePatchV1OrganizationsIdActive";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/admin/empty-state";
+import { Pager } from "@/components/admin/pager";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { cn } from "@/lib/utils";
+import { CreateOrganizationDialog } from "./_components/create-organization-dialog";
+import { EditOrganizationDialog } from "./_components/edit-organization-dialog";
+import {
+  OrganizationsTable,
+  type OrganizationRow,
+} from "./_components/organizations-table";
+
+type FilterMode = "all" | "active" | "inactive";
+
+const PER_PAGE = 20;
+
+export default function OrganizationsPage() {
+  const queryClient = useQueryClient();
+
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const [filter, setFilter] = useState<FilterMode>("all");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOrg, setEditOrg] = useState<OrganizationRow | null>(null);
+
+  const params = useMemo(
+    () => ({
+      page,
+      perPage: PER_PAGE,
+      ...(debouncedSearch.trim().length > 0 ? { q: debouncedSearch.trim() } : {}),
+      includeInactive: filter !== "active",
+    }),
+    [page, debouncedSearch, filter],
+  );
+
+  const { data, isLoading, isFetching, error, refetch } = useGetV1Organizations(
+    params,
+  );
+
+  const allRows: OrganizationRow[] = data?.data ?? [];
+  const rows = useMemo(() => {
+    if (filter === "inactive") return allRows.filter((o) => !o.isActive);
+    return allRows;
+  }, [allRows, filter]);
+
+  const pagination = data?.pagination ?? {
+    total: 0,
+    page: 1,
+    perPage: PER_PAGE,
+    totalPages: 1,
+  };
+
+  const totalsActive = allRows.filter((o) => o.isActive).length;
+  const totalsInactive = allRows.filter((o) => !o.isActive).length;
+  const totalsAll = pagination.total;
+
+  const toggleActive = usePatchV1OrganizationsIdActive({
+    mutation: {
+      onSuccess: (_res, vars) => {
+        toast.success("Status atualizado");
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return first?.url === "/v1/organizations/" || first?.url === "/v1/organizations/:id";
+          },
+        });
+        // Touch the variable to keep it referenced for ts-strict noUnusedParameters compatibility.
+        void vars;
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao atualizar status",
+        );
+      },
+    },
+  });
+
+  const handleToggleActive = (org: OrganizationRow) => {
+    toggleActive.mutate({ id: org.id, data: { isActive: !org.isActive } });
+  };
+
+  const showInitialEmpty =
+    !isLoading && !error && rows.length === 0 && !debouncedSearch && filter === "all";
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Organizações</h1>
+          <p className="mt-1 text-sm text-slate-400">
+            {totalsActive} ativas · {totalsInactive} inativas · {totalsAll} no total
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+          >
+            <Plus className="mr-1.5 h-4 w-4" />
+            Nova organização
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <Input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            placeholder="Buscar por nome ou slug…"
+            className="bg-slate-900 border-slate-700 pl-9 pr-9 text-white placeholder:text-slate-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearch("");
+                setPage(1);
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 hover:text-white"
+              aria-label="Limpar busca"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 rounded-md border border-slate-700 bg-slate-900 p-1">
+          {(
+            [
+              { id: "all", label: "Todas" },
+              { id: "active", label: "Ativas" },
+              { id: "inactive", label: "Inativas" },
+            ] as { id: FilterMode; label: string }[]
+          ).map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => {
+                setFilter(opt.id);
+                setPage(1);
+              }}
+              className={cn(
+                "rounded px-3 py-1 text-xs font-medium transition-colors",
+                filter === opt.id
+                  ? "bg-slate-700 text-white"
+                  : "text-slate-400 hover:text-white",
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error ? (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" />
+            <span>
+              Não foi possível carregar as organizações.{" "}
+              {error instanceof Error ? error.message : ""}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void refetch();
+            }}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Tentar novamente
+          </Button>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/40">
+          {showInitialEmpty ? (
+            <EmptyState
+              icon={Building2}
+              title="Ainda não há organizações"
+              body="Crie a primeira organização para começar a cadastrar membros e domínios."
+              action={
+                <Button
+                  type="button"
+                  onClick={() => setCreateOpen(true)}
+                  className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+                >
+                  <Plus className="mr-1.5 h-4 w-4" />
+                  Criar primeira organização
+                </Button>
+              }
+            />
+          ) : !isLoading && rows.length === 0 ? (
+            <EmptyState
+              icon={Building2}
+              title="Nenhuma organização encontrada"
+              body={
+                debouncedSearch
+                  ? `Nada corresponde a "${debouncedSearch}".`
+                  : "Tente um filtro diferente."
+              }
+            />
+          ) : (
+            <>
+              <OrganizationsTable
+                rows={rows}
+                isLoading={isLoading || (isFetching && rows.length === 0)}
+                onEdit={(org) => setEditOrg(org)}
+                onToggleActive={handleToggleActive}
+                togglingId={
+                  toggleActive.isPending
+                    ? (toggleActive.variables as { id?: string } | undefined)?.id
+                    : undefined
+                }
+              />
+              <Pager
+                page={pagination.page}
+                perPage={pagination.perPage}
+                total={pagination.total}
+                totalPages={pagination.totalPages}
+                onPageChange={setPage}
+              />
+            </>
+          )}
+        </div>
+      )}
+
+      <CreateOrganizationDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <EditOrganizationDialog
+        open={!!editOrg}
+        onOpenChange={(open) => {
+          if (!open) setEditOrg(null);
+        }}
+        org={editOrg}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/page.tsx
@@ -40,25 +40,34 @@ export default function OrganizationsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editOrg, setEditOrg] = useState<OrganizationRow | null>(null);
 
+  // Filter is handled server-side via `includeInactive`:
+  // - "active":   includeInactive=false (default) → only active rows
+  // - "all":      includeInactive=true            → active + inactive rows
+  // - "inactive": includeInactive=true + client-side filter on the page
+  //   (the API has no "inactive only" parameter today; pagination is hidden
+  //   in this mode to avoid misleading totals — see hidePager below.)
+  const includeInactive = filter !== "active";
+
   const params = useMemo(
     () => ({
       page,
       perPage: PER_PAGE,
-      ...(debouncedSearch.trim().length > 0 ? { q: debouncedSearch.trim() } : {}),
-      includeInactive: filter !== "active",
+      ...(debouncedSearch.trim().length > 0
+        ? { q: debouncedSearch.trim() }
+        : {}),
+      includeInactive,
     }),
-    [page, debouncedSearch, filter],
+    [page, debouncedSearch, includeInactive],
   );
 
-  const { data, isLoading, isFetching, error, refetch } = useGetV1Organizations(
-    params,
-  );
+  const { data, isLoading, isFetching, error, refetch } =
+    useGetV1Organizations(params);
 
-  const allRows: OrganizationRow[] = data?.data ?? [];
+  const fetchedRows: OrganizationRow[] = data?.data ?? [];
   const rows = useMemo(() => {
-    if (filter === "inactive") return allRows.filter((o) => !o.isActive);
-    return allRows;
-  }, [allRows, filter]);
+    if (filter === "inactive") return fetchedRows.filter((o) => !o.isActive);
+    return fetchedRows;
+  }, [fetchedRows, filter]);
 
   const pagination = data?.pagination ?? {
     total: 0,
@@ -67,9 +76,11 @@ export default function OrganizationsPage() {
     totalPages: 1,
   };
 
-  const totalsActive = allRows.filter((o) => o.isActive).length;
-  const totalsInactive = allRows.filter((o) => !o.isActive).length;
-  const totalsAll = pagination.total;
+  // When "Inativas" is selected, the count of items returned reflects the
+  // current page only (because filtering is post-fetch). Hiding the pager
+  // avoids showing wrong page counts. "Todas" / "Ativas" use server-side
+  // filters, so pagination is reliable.
+  const hidePager = filter === "inactive";
 
   const toggleActive = usePatchV1OrganizationsIdActive({
     mutation: {
@@ -78,7 +89,10 @@ export default function OrganizationsPage() {
         void queryClient.invalidateQueries({
           predicate: (query) => {
             const first = query.queryKey[0] as { url?: string } | undefined;
-            return first?.url === "/v1/organizations/" || first?.url === "/v1/organizations/:id";
+            return (
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/organizations/:id"
+            );
           },
         });
         // Touch the variable to keep it referenced for ts-strict noUnusedParameters compatibility.
@@ -97,16 +111,31 @@ export default function OrganizationsPage() {
   };
 
   const showInitialEmpty =
-    !isLoading && !error && rows.length === 0 && !debouncedSearch && filter === "all";
+    !isLoading &&
+    !error &&
+    rows.length === 0 &&
+    !debouncedSearch &&
+    filter === "all";
+
+  // Header summary uses `pagination.total`, which respects server-side
+  // filters (search + includeInactive). For "Inativas" we cannot compute a
+  // global count without API support; fall back to "X nesta página".
+  const summaryText = (() => {
+    if (filter === "inactive") {
+      return `${rows.length} inativa(s) nesta página`;
+    }
+    if (filter === "active") {
+      return `${pagination.total} ativa(s)`;
+    }
+    return `${pagination.total} no total`;
+  })();
 
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold text-white">Organizações</h1>
-          <p className="mt-1 text-sm text-slate-400">
-            {totalsActive} ativas · {totalsInactive} inativas · {totalsAll} no total
-          </p>
+          <p className="mt-1 text-sm text-slate-400">{summaryText}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -233,17 +262,20 @@ export default function OrganizationsPage() {
                 onToggleActive={handleToggleActive}
                 togglingId={
                   toggleActive.isPending
-                    ? (toggleActive.variables as { id?: string } | undefined)?.id
+                    ? (toggleActive.variables as { id?: string } | undefined)
+                        ?.id
                     : undefined
                 }
               />
-              <Pager
-                page={pagination.page}
-                perPage={pagination.perPage}
-                total={pagination.total}
-                totalPages={pagination.totalPages}
-                onPageChange={setPage}
-              />
+              {!hidePager && (
+                <Pager
+                  page={pagination.page}
+                  perPage={pagination.perPage}
+                  total={pagination.total}
+                  totalPages={pagination.totalPages}
+                  onPageChange={setPage}
+                />
+              )}
             </>
           )}
         </div>

--- a/apps/web/src/app/(inside)/admin/page.tsx
+++ b/apps/web/src/app/(inside)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminIndexPage() {
+  redirect("/admin/organizations");
+}

--- a/apps/web/src/components/admin/avatar-square.tsx
+++ b/apps/web/src/components/admin/avatar-square.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/lib/utils";
+
+const palette = [
+  "bg-amber-500/20 text-amber-300",
+  "bg-emerald-500/20 text-emerald-300",
+  "bg-sky-500/20 text-sky-300",
+  "bg-violet-500/20 text-violet-300",
+  "bg-rose-500/20 text-rose-300",
+  "bg-cyan-500/20 text-cyan-300",
+];
+
+function pickColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
+    hash |= 0;
+  }
+  const idx = Math.abs(hash) % palette.length;
+  return palette[idx] ?? palette[0]!;
+}
+
+function getInitials(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "?";
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  const first = parts[0]?.[0] ?? "";
+  const last = parts[parts.length - 1]?.[0] ?? "";
+  return `${first}${last}`.toUpperCase();
+}
+
+interface AvatarSquareProps {
+  name: string;
+  src?: string | null;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function AvatarSquare({ name, src, size = "md", className }: AvatarSquareProps) {
+  const sizeClass =
+    size === "sm"
+      ? "h-8 w-8 text-xs rounded-md"
+      : size === "lg"
+        ? "h-14 w-14 text-lg rounded-xl"
+        : "h-10 w-10 text-sm rounded-lg";
+
+  if (src) {
+    return (
+      <div
+        className={cn(
+          "shrink-0 overflow-hidden border border-white/10",
+          sizeClass,
+          className,
+        )}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt={name} className="h-full w-full object-cover" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center font-semibold border border-white/10",
+        sizeClass,
+        pickColor(name),
+        className,
+      )}
+      aria-hidden
+    >
+      {getInitials(name)}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/empty-state.tsx
+++ b/apps/web/src/components/admin/empty-state.tsx
@@ -1,0 +1,38 @@
+import type { LucideIcon } from "lucide-react";
+import { Inbox } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  body?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon = Inbox,
+  title,
+  body,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 px-6 py-12 text-center",
+        className,
+      )}
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-slate-800/60 text-slate-400 border border-slate-700/60">
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="space-y-1">
+        <h4 className="text-sm font-semibold text-white">{title}</h4>
+        {body && <p className="text-xs text-slate-400 max-w-md">{body}</p>}
+      </div>
+      {action && <div className="mt-1">{action}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/org-cell.tsx
+++ b/apps/web/src/components/admin/org-cell.tsx
@@ -1,0 +1,19 @@
+import { AvatarSquare } from "./avatar-square";
+
+interface OrgCellProps {
+  name: string;
+  slug: string;
+  logo?: string | null;
+}
+
+export function OrgCell({ name, slug, logo }: OrgCellProps) {
+  return (
+    <div className="flex items-center gap-3 min-w-0">
+      <AvatarSquare name={name} src={logo} size="md" />
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium text-white">{name}</span>
+        <span className="truncate text-xs text-slate-400">@{slug}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/pager.tsx
+++ b/apps/web/src/components/admin/pager.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface PagerProps {
+  page: number;
+  perPage: number;
+  total: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+function buildPageList(current: number, totalPages: number): (number | "ellipsis")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "ellipsis")[] = [];
+  const add = (p: number | "ellipsis") => pages.push(p);
+
+  add(1);
+  if (current > 4) add("ellipsis");
+
+  const start = Math.max(2, current - 1);
+  const end = Math.min(totalPages - 1, current + 1);
+  for (let p = start; p <= end; p++) add(p);
+
+  if (current < totalPages - 3) add("ellipsis");
+  add(totalPages);
+
+  return pages;
+}
+
+export function Pager({ page, perPage, total, totalPages, onPageChange }: PagerProps) {
+  if (total === 0) return null;
+
+  const start = (page - 1) * perPage + 1;
+  const end = Math.min(page * perPage, total);
+  const pages = buildPageList(page, totalPages);
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-slate-700/60 bg-slate-800/30 px-4 py-3 text-xs text-slate-400">
+      <div>
+        Mostrando <strong className="text-white">{start}–{end}</strong> de {total}
+      </div>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md border border-slate-700/60 text-slate-300 hover:bg-slate-700/40 disabled:opacity-40",
+          )}
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+          disabled={page <= 1}
+          aria-label="Página anterior"
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+        </button>
+        {pages.map((p, idx) =>
+          p === "ellipsis" ? (
+            <span key={`e-${idx}`} className="px-1 text-slate-500">
+              …
+            </span>
+          ) : (
+            <button
+              key={p}
+              type="button"
+              className={cn(
+                "flex h-7 min-w-7 items-center justify-center rounded-md border px-2 text-xs font-medium",
+                p === page
+                  ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
+                  : "border-slate-700/60 text-slate-300 hover:bg-slate-700/40",
+              )}
+              onClick={() => onPageChange(p)}
+              aria-current={p === page ? "page" : undefined}
+            >
+              {p}
+            </button>
+          ),
+        )}
+        <button
+          type="button"
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-md border border-slate-700/60 text-slate-300 hover:bg-slate-700/40 disabled:opacity-40",
+          )}
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+          disabled={page >= totalPages}
+          aria-label="Próxima página"
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/role-badge.tsx
+++ b/apps/web/src/components/admin/role-badge.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+export type AdminRole = "student" | "teacher" | "coordinator" | "admin";
+
+const roleLabel: Record<AdminRole, string> = {
+  student: "Aluno",
+  teacher: "Professor",
+  coordinator: "Coordenador",
+  admin: "Administrador",
+};
+
+const roleClass: Record<AdminRole, string> = {
+  student: "bg-sky-500/10 text-sky-300 border-sky-500/30",
+  teacher: "bg-emerald-500/10 text-emerald-300 border-emerald-500/30",
+  coordinator: "bg-violet-500/10 text-violet-300 border-violet-500/30",
+  admin: "bg-amber-500/10 text-amber-300 border-amber-500/30",
+};
+
+interface RoleBadgeProps {
+  role: AdminRole;
+  className?: string;
+}
+
+export function RoleBadge({ role, className }: RoleBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+        roleClass[role],
+        className,
+      )}
+    >
+      {roleLabel[role]}
+    </span>
+  );
+}
+
+export function getRoleLabel(role: AdminRole): string {
+  return roleLabel[role];
+}
+
+export function isAdminRole(value: string): value is AdminRole {
+  return value === "student" || value === "teacher" || value === "coordinator" || value === "admin";
+}

--- a/apps/web/src/components/admin/status-pill.tsx
+++ b/apps/web/src/components/admin/status-pill.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+
+interface StatusPillProps {
+  active: boolean;
+  className?: string;
+}
+
+export function StatusPill({ active, className }: StatusPillProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-medium",
+        active
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+          : "border-slate-600/40 bg-slate-700/30 text-slate-400",
+        className,
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 rounded-full",
+          active ? "bg-emerald-400" : "bg-slate-500",
+        )}
+      />
+      {active ? "Ativa" : "Inativa"}
+    </span>
+  );
+}

--- a/apps/web/src/components/admin/user-cell.tsx
+++ b/apps/web/src/components/admin/user-cell.tsx
@@ -1,0 +1,19 @@
+import { AvatarSquare } from "./avatar-square";
+
+interface UserCellProps {
+  name: string;
+  email: string;
+  image?: string | null;
+}
+
+export function UserCell({ name, email, image }: UserCellProps) {
+  return (
+    <div className="flex items-center gap-3 min-w-0">
+      <AvatarSquare name={name} src={image} size="md" />
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium text-white">{name}</span>
+        <span className="truncate text-xs text-slate-400">{email}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useDebouncedValue.ts
+++ b/apps/web/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms of stillness.
+ * Useful to avoid spamming network calls while the user is typing.
+ */
+export function useDebouncedValue<T>(value: T, delay = 250): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
Adds the frontend shell for `/admin` and Phase 2 (organizations CRUD) UI. Stacks on the integration branch (`feat/admin-backend-integration`); merge into that, not `main`.

Closes the frontend portion of #62.

## Screens covered
- `/admin` — shell with sidebar (Organizações, Usuários) + topbar with auto breadcrumbs; redirects to `/admin/organizations`
- `/admin/organizations` — paginated list with debounced search, segmented filter (Todas / Ativas / Inativas), inline status toggle, create dialog
- `/admin/organizations/[id]` — detail layout with avatar/name/status header, edit + toggle actions, Membros / Domínios / Configurações tabs
- `/admin/organizations/[id]/settings` — edit form + Zona de risco card with confirm AlertDialog
- AccessDenied for non-platform admins

## Out of scope (other agents)
- `/admin/organizations/[id]/members` content (Agent B) — placeholder shipped so the tab does not 404
- `/admin/organizations/[id]/domains` content (Agent D) — placeholder shipped so the tab does not 404
- `/admin/users` (Agent B)
- CSV import modal (Agent C)

## Implementation notes
- Uses Kubb-generated hooks under `apps/web/src/kubb/hooks/organizationsHooks/` (`useGetV1Organizations`, `useGetV1OrganizationsId`, `usePostV1Organizations`, `usePutV1OrganizationsId`, `usePatchV1OrganizationsIdActive`).
- Forms use `react-hook-form` + `@hookform/resolvers/zod`, matching the existing `profile/page.tsx` pattern.
- Mutations show success/error via `sonner` toasts and invalidate the relevant list / detail queries so callers refetch.
- Role mapping (per `project_admin_bootstrap_decisions`): design's `owner→admin`, `admin→coordinator`, `member→teacher`, `student→student`. Labels in pt-BR (Aluno, Professor, Coordenador, Administrador).
- Sidebar deliberately omits Audit log / Usage / Settings / Impersonate items from the design prototype — none are in scope per the decisions in memory.
- No `organization.plan` column was used; the "Federal/School" badge from the prototype is intentionally not implemented.
- Slug input auto-generates from name on create, lowercase normalization on every keystroke; edit mode does not auto-fill the slug.

## Shared primitives shipped (under `apps/web/src/components/admin/`)
- `RoleBadge` — pt-BR labels with color variants for the four roles
- `StatusPill` — Ativa/Inativa with status dot
- `OrgCell`, `UserCell` — avatar + name + secondary line for tables
- `AvatarSquare` — square avatar with deterministic color and initials fallback
- `EmptyState` — icon + title + body + optional action
- `Pager` — page numbers + prev/next + "Mostrando X–Y de Z"

Plus a small `useDebouncedValue` hook in `apps/web/src/hooks/`.

## Verification
- `apps/web` typecheck delta is clean — only the pre-existing errors (`process`/`require` typings, `UserContext` `organization` lookup) remain. No new errors introduced by this PR.
- Lint and build infra is broken inside the git worktree (no installed `node_modules`); compile via `tsc --noEmit` against the main repo's `node_modules` passes for all new files.

## Test plan (manual smoke)
- [ ] Sign in as platform admin (`PLATFORM_ADMIN_EMAIL` + password from `.env`)
- [ ] Navbar shows "Admin" link
- [ ] Click → `/admin` → redirects to `/admin/organizations`
- [ ] Sign in as a non-platform-admin teacher → `/admin` shows AccessDenied
- [ ] List loads with paginated data, search debounces, filter switches between Todas/Ativas/Inativas
- [ ] "Nova organização" opens dialog, validation works on name and slug, submit creates and refetches
- [ ] Click row → `/admin/organizations/:id` → loads detail, tabs visible
- [ ] Tab switching changes URL but stays in layout
- [ ] Settings tab → edit name → success toast, list and detail invalidated
- [ ] Deactivate confirmation → success, status pill flips to "Inativa"
- [ ] Reactivate works

## Commits
- `feat(web): add admin shell with sidebar, topbar, breadcrumbs and access denied`
- `feat(web): add platform admin link to main navbar`
- `feat(web): add shared admin primitives and useDebouncedValue hook`
- `feat(web): add create and edit organization dialogs`
- `feat(web): add admin organizations list page with search and filters`
- `feat(web): add organization detail layout with header and tabs`
- `feat(web): add organization settings tab with danger zone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)