### PR TITLE
feat(web): admin domains tab (#65 frontend)

### DIFF
--- a/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/add-domain-form.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/add-domain-form.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, Plus } from "lucide-react";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ApiError } from "@/lib/apiClient";
+import { usePostV1OrganizationsIdEmailDomains } from "@/kubb/hooks/organizationsHooks/usePostV1OrganizationsIdEmailDomains";
+import { getV1OrganizationsIdEmailDomainsQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdEmailDomains";
+import type { AdminRole } from "@/components/admin/role-badge";
+import { getRoleLabel } from "@/components/admin/role-badge";
+
+interface AddDomainFormProps {
+  organizationId: string;
+}
+
+const ROLE_OPTIONS: AdminRole[] = [
+  "student",
+  "teacher",
+  "coordinator",
+  "admin",
+];
+
+const DEFAULT_ROLE: AdminRole = "teacher";
+
+// Mirrors backend normalization in
+// apps/api/src/http/routes/v1/organizations/email-domains/create.ts
+const domainSchema = z
+  .string()
+  .min(3, "Domínio precisa ter ao menos 3 caracteres")
+  .max(253, "Domínio muito longo")
+  .transform((s) => s.toLowerCase().trim().replace(/^@/, ""))
+  .refine(
+    (s) =>
+      /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(
+        s,
+      ),
+    { message: "Formato de domínio inválido (ex.: exemplo.edu.br)" },
+  );
+
+export function AddDomainForm({ organizationId }: AddDomainFormProps) {
+  const queryClient = useQueryClient();
+  const [domain, setDomain] = useState("");
+  const [role, setRole] = useState<AdminRole>(DEFAULT_ROLE);
+  const [error, setError] = useState<string | null>(null);
+
+  const createMutation = usePostV1OrganizationsIdEmailDomains({
+    mutation: {
+      onSuccess: (response) => {
+        toast.success(`Domínio "${response.data.domain}" adicionado`);
+        setDomain("");
+        setRole(DEFAULT_ROLE);
+        setError(null);
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdEmailDomainsQueryKey(organizationId),
+        });
+      },
+      onError: (err) => {
+        const apiError = err as unknown as ApiError | undefined;
+        const status = apiError?.status;
+        const message =
+          err instanceof Error ? err.message : "Erro ao adicionar domínio";
+
+        if (status === 409) {
+          setError(message);
+          return;
+        }
+
+        setError(message);
+        toast.error(message);
+      },
+    },
+  });
+
+  function reset() {
+    setError(null);
+  }
+
+  function submit() {
+    if (createMutation.isPending) return;
+
+    const parsed = domainSchema.safeParse(domain);
+    if (!parsed.success) {
+      const message =
+        parsed.error.errors[0]?.message ?? "Domínio inválido";
+      setError(message);
+      return;
+    }
+
+    setError(null);
+    createMutation.mutate({
+      id: organizationId,
+      data: {
+        domain: parsed.data,
+        role,
+      },
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    submit();
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <Card className="bg-slate-900/60 border-slate-700/60 text-white">
+      <CardHeader>
+        <CardTitle className="text-base">Adicionar domínio</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={handleSubmit}
+          className="grid gap-3 md:grid-cols-[1fr_180px_auto] md:items-start"
+          noValidate
+        >
+          <div className="space-y-1.5">
+            <div className="flex items-center rounded-md border border-slate-700/60 bg-slate-950/60 focus-within:border-amber-400/60">
+              <span className="select-none px-3 py-2 text-sm text-slate-500">
+                @
+              </span>
+              <Input
+                value={domain}
+                onChange={(e) => {
+                  setDomain(e.target.value);
+                  reset();
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder="exemplo.edu.br"
+                className="h-10 flex-1 border-0 bg-transparent px-0 text-sm text-white placeholder:text-slate-500 focus-visible:ring-0 focus-visible:ring-offset-0"
+                aria-label="Domínio"
+                aria-invalid={error ? true : undefined}
+                disabled={createMutation.isPending}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </div>
+            {error && (
+              <p className="text-xs text-red-400" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+
+          <Select
+            value={role}
+            onValueChange={(value) => {
+              setRole(value as AdminRole);
+              reset();
+            }}
+            disabled={createMutation.isPending}
+          >
+            <SelectTrigger
+              className="h-10 border-slate-700/60 bg-slate-950/60 text-sm text-white"
+              aria-label="Papel atribuído"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-slate-900 border-slate-700 text-white">
+              {ROLE_OPTIONS.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {getRoleLabel(value)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            type="submit"
+            disabled={createMutation.isPending}
+            className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+          >
+            {createMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Adicionar domínio
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/add-domain-form.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/add-domain-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { FormEvent, KeyboardEvent } from "react";
+import type { FormEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Plus } from "lucide-react";
 import { toast } from "sonner";
@@ -114,13 +114,6 @@ export function AddDomainForm({ organizationId }: AddDomainFormProps) {
     submit();
   }
 
-  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      submit();
-    }
-  }
-
   return (
     <Card className="bg-slate-900/60 border-slate-700/60 text-white">
       <CardHeader>
@@ -143,7 +136,6 @@ export function AddDomainForm({ organizationId }: AddDomainFormProps) {
                   setDomain(e.target.value);
                   reset();
                 }}
-                onKeyDown={handleKeyDown}
                 placeholder="exemplo.edu.br"
                 className="h-10 flex-1 border-0 bg-transparent px-0 text-sm text-white placeholder:text-slate-500 focus-visible:ring-0 focus-visible:ring-offset-0"
                 aria-label="Domínio"

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/domains-table.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/domains/_components/domains-table.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Globe, Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { EmptyState } from "@/components/admin/empty-state";
+import { RoleBadge } from "@/components/admin/role-badge";
+import type { AdminRole } from "@/components/admin/role-badge";
+import { isAdminRole } from "@/components/admin/role-badge";
+import { useDeleteV1OrganizationsIdEmailDomainsDomainid } from "@/kubb/hooks/organizationsHooks/useDeleteV1OrganizationsIdEmailDomainsDomainid";
+import { getV1OrganizationsIdEmailDomainsQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdEmailDomains";
+
+export interface DomainRow {
+  id: string;
+  domain: string;
+  role: string;
+  createdAt: string;
+}
+
+interface DomainsTableProps {
+  organizationId: string;
+  rows: DomainRow[];
+  isLoading: boolean;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return dateFormatter.format(d);
+}
+
+function toAdminRole(role: string): AdminRole {
+  return isAdminRole(role) ? role : "student";
+}
+
+export function DomainsTable({
+  organizationId,
+  rows,
+  isLoading,
+}: DomainsTableProps) {
+  const queryClient = useQueryClient();
+  const [pendingDelete, setPendingDelete] = useState<DomainRow | null>(null);
+
+  const deleteMutation = useDeleteV1OrganizationsIdEmailDomainsDomainid({
+    mutation: {
+      onSuccess: () => {
+        toast.success(`Domínio "${pendingDelete?.domain}" removido`);
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdEmailDomainsQueryKey(organizationId),
+        });
+        setPendingDelete(null);
+      },
+      onError: (err) => {
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao remover domínio",
+        );
+      },
+    },
+  });
+
+  const showEmpty = !isLoading && rows.length === 0;
+
+  return (
+    <div className="rounded-lg border border-slate-700/60 bg-slate-900/60">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-slate-700/60 hover:bg-transparent">
+            <TableHead className="text-slate-400">Domínio</TableHead>
+            <TableHead className="text-slate-400">Papel</TableHead>
+            <TableHead className="text-slate-400">Adicionado em</TableHead>
+            <TableHead className="text-right text-slate-400">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading &&
+            Array.from({ length: 3 }).map((_, i) => (
+              <TableRow key={`sk-${i}`} className="border-slate-700/60">
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-4 rounded bg-slate-800" />
+                    <Skeleton className="h-3 w-40 bg-slate-800" />
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-5 w-20 bg-slate-800" />
+                </TableCell>
+                <TableCell>
+                  <Skeleton className="h-3 w-24 bg-slate-800" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-7 w-7 bg-slate-800" />
+                </TableCell>
+              </TableRow>
+            ))}
+
+          {!isLoading &&
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                className="border-slate-700/60 hover:bg-slate-800/40"
+              >
+                <TableCell className="py-3">
+                  <span className="inline-flex items-center gap-2 font-mono text-sm font-medium text-white">
+                    <Globe className="h-4 w-4 text-amber-400" />@{row.domain}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <RoleBadge role={toAdminRole(row.role)} />
+                </TableCell>
+                <TableCell className="text-xs text-slate-400">
+                  {formatDate(row.createdAt)}
+                </TableCell>
+                <TableCell className="text-right">
+                  <button
+                    type="button"
+                    title="Remover domínio"
+                    aria-label={`Remover domínio ${row.domain}`}
+                    onClick={() => setPendingDelete(row)}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-red-400/80 hover:bg-red-500/10 hover:text-red-300"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </TableCell>
+              </TableRow>
+            ))}
+
+          {showEmpty && (
+            <TableRow className="border-slate-700/60 hover:bg-transparent">
+              <TableCell colSpan={4}>
+                <EmptyState
+                  icon={Globe}
+                  title="Nenhum domínio configurado"
+                  body="Adicione um domínio acima para habilitar o vínculo automático para emails correspondentes."
+                />
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent className="bg-slate-900 border-slate-700 text-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover domínio?</AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-400">
+              {pendingDelete
+                ? `O domínio "@${pendingDelete.domain}" deixará de vincular automaticamente novos usuários a esta organização. Membros já criados não serão afetados.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>
+              Cancelar
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleteMutation.isPending}
+              onClick={(e) => {
+                e.preventDefault();
+                if (!pendingDelete) return;
+                deleteMutation.mutate({
+                  id: organizationId,
+                  domainId: pendingDelete.id,
+                });
+              }}
+              className="bg-red-500 text-white hover:bg-red-400"
+            >
+              {deleteMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              Sim, remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/domains/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/domains/page.tsx
@@ -1,16 +1,83 @@
-import { Globe } from "lucide-react";
-import { EmptyState } from "@/components/admin/empty-state";
+"use client";
 
-/**
- * Placeholder owned by Agent D (domains tab).
- * Lives here so the Domínios tab does not 404 while the real page is wired.
- */
-export default function DomainsTabPlaceholderPage() {
+import { useParams } from "next/navigation";
+import { Info, RefreshCw } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { useGetV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { useGetV1OrganizationsIdEmailDomains } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdEmailDomains";
+import { AddDomainForm } from "./_components/add-domain-form";
+import { DomainsTable } from "./_components/domains-table";
+
+export default function OrganizationDomainsPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id ?? "";
+
+  const orgQuery = useGetV1OrganizationsId(id, {
+    query: { enabled: id.length > 0 },
+  });
+  const orgName = orgQuery.data?.data.name ?? "esta organização";
+
+  const domainsQuery = useGetV1OrganizationsIdEmailDomains(id, {
+    query: { enabled: id.length > 0 },
+  });
+
+  const rows = domainsQuery.data?.data ?? [];
+  const isLoading = domainsQuery.isLoading;
+
   return (
-    <EmptyState
-      icon={Globe}
-      title="Em construção"
-      body="A aba de domínios será entregue em breve pelo agente responsável."
-    />
+    <div className="space-y-5">
+      <Alert className="border-amber-500/30 bg-amber-500/5 text-amber-100">
+        <Info className="h-4 w-4 text-amber-400" />
+        <AlertTitle className="text-white">
+          Vínculo automático por domínio
+        </AlertTitle>
+        <AlertDescription className="text-slate-300">
+          Usuários que se cadastrarem com um email cujo domínio bata com um dos
+          abaixo serão adicionados a{" "}
+          <strong className="text-white">{orgName}</strong> automaticamente, com
+          o papel definido. A regra com a data de criação mais antiga vence
+          quando há múltiplas correspondências.
+        </AlertDescription>
+      </Alert>
+
+      <AddDomainForm organizationId={id} />
+
+      {domainsQuery.isError ? (
+        <Alert variant="destructive" className="border-red-500/30 bg-red-500/5">
+          <AlertTitle className="text-red-200">
+            Erro ao carregar domínios
+          </AlertTitle>
+          <AlertDescription className="text-red-300">
+            <div className="mb-3">
+              {domainsQuery.error instanceof Error
+                ? domainsQuery.error.message
+                : "Tente novamente em instantes."}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => domainsQuery.refetch()}
+              disabled={domainsQuery.isFetching}
+              className="border-red-500/40 text-red-200 hover:bg-red-500/10 hover:text-red-100"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 ${
+                  domainsQuery.isFetching ? "animate-spin" : ""
+                }`}
+              />
+              Tentar novamente
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <DomainsTable
+          organizationId={id}
+          rows={rows}
+          isLoading={isLoading}
+        />
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Implements the Domínios tab for organization detail. Closes #65 (frontend). Stacks on #81 (Agent A: admin shell + orgs primitives).

- Info banner explaining auto-assignment ("regra mais antiga vence")
- Add-domain form card: prefixed `@` input, role select (Aluno/Professor/Coordenador/Administrador, default Professor), submit on Enter, client-side Zod validation mirroring the backend regex/normalization
- Domains list table: globe + monospace `@domain`, RoleBadge, pt-BR date, delete action gated by AlertDialog
- Loading skeletons, empty state with `EmptyState` primitive, error state with retry

## Out of scope
- DNS verification flow (decision: skip in MVP — not implementing "Verified / Pending DNS" pills or "Verify" action)
- "Adicionado por" column (backend doesn't expose `addedByUserId` — column omitted)

## Decisions captured
- Roles: `student | teacher | coordinator | admin` with pt-BR labels via Agent A's `RoleBadge`
- 409 surfaced as inline form error (preserves backend message that includes the conflicting org name) — no toast for 409
- Other errors: inline error + toast
- Domain input lowercased/trimmed and `@` prefix stripped before send (mirrors backend Zod transform)

## Test plan
- [ ] Sign in as platform admin
- [ ] Navigate to `/admin/organizations/<id>/domains`
- [ ] Empty state renders when no domains
- [ ] Add `ifsp.edu.br` with Professor → success toast + appears in table
- [ ] Add same domain again with same role → 409 inline error with conflicting org name
- [ ] Delete domain → confirmation dialog → table updates
- [ ] Sign up new user with email matching a domain → backend hook creates `member` (out of scope for this PR — verify dev loop works)

## Verification
- `cd apps/web && npm run typecheck` — clean delta (8 pre-existing errors, no new ones from this branch)
- Next.js compiled successfully (`✓ Compiled successfully`); the worktree-local `next build` could not finish because the worktree lacks installed `node_modules` (same failure on the parent branch with no changes — confirmed via stash). CI/local dev install will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)