### PR TITLE
feat(web): admin members tab + global users page + 3 modals (#63)

### DIFF
--- a/apps/web/src/app/(inside)/admin/organizations/[id]/members/_components/members-table.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/members/_components/members-table.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import {
+  ArrowRightLeft,
+  Eye,
+  Globe,
+  Lock,
+  Mail,
+  MoreHorizontal,
+  UserMinus,
+} from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { UserCell } from "@/components/admin/user-cell";
+import { RoleSelect } from "@/components/admin/role-select";
+import { isAdminRole } from "@/components/admin/role-badge";
+import type { AdminRole } from "@/components/admin/role-badge";
+import { formatRelativeTimePtBR } from "@/lib/relative-time";
+
+export interface MemberRow {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+  createdAt: string;
+  lastActiveAt: string | null;
+  joinedVia: "domain" | "manual" | "invitation";
+}
+
+interface MembersTableProps {
+  rows: MemberRow[];
+  isLoading: boolean;
+  isSoloAdmin: (row: MemberRow) => boolean;
+  pendingRoleUserId: string | undefined;
+  onRoleChange: (row: MemberRow, role: AdminRole) => void;
+  onMove: (row: MemberRow) => void;
+  onRemove: (row: MemberRow) => void;
+}
+
+const joinedViaLabel: Record<MemberRow["joinedVia"], string> = {
+  domain: "Domínio",
+  manual: "Manual",
+  invitation: "Convite",
+};
+
+function emailDomain(email: string): string {
+  const at = email.lastIndexOf("@");
+  return at >= 0 ? email.slice(at + 1) : email;
+}
+
+export function MembersTable({
+  rows,
+  isLoading,
+  isSoloAdmin,
+  pendingRoleUserId,
+  onRoleChange,
+  onMove,
+  onRemove,
+}: MembersTableProps) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Table>
+        <TableHeader>
+          <TableRow className="border-slate-700/60 hover:bg-transparent">
+            <TableHead className="text-slate-400">Membro</TableHead>
+            <TableHead className="text-slate-400">Papel</TableHead>
+            <TableHead className="text-slate-400">Última atividade</TableHead>
+            <TableHead className="text-slate-400">Origem</TableHead>
+            <TableHead className="text-right text-slate-400">Ações</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading
+            ? Array.from({ length: 6 }).map((_, i) => (
+                <TableRow key={`sk-${i}`} className="border-slate-700/60">
+                  <TableCell>
+                    <div className="flex items-center gap-3">
+                      <Skeleton className="h-10 w-10 rounded-lg bg-slate-800" />
+                      <div className="space-y-1.5">
+                        <Skeleton className="h-3 w-40 bg-slate-800" />
+                        <Skeleton className="h-2.5 w-28 bg-slate-800" />
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-8 w-32 bg-slate-800" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-3 w-20 bg-slate-800" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-3 w-24 bg-slate-800" />
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Skeleton className="ml-auto h-7 w-7 bg-slate-800" />
+                  </TableCell>
+                </TableRow>
+              ))
+            : rows.map((row) => {
+                const role: AdminRole = isAdminRole(row.role)
+                  ? row.role
+                  : "teacher";
+                const solo = isSoloAdmin(row);
+                const pending = pendingRoleUserId === row.userId;
+
+                return (
+                  <TableRow
+                    key={row.id}
+                    className="border-slate-700/60 hover:bg-slate-800/30"
+                  >
+                    <TableCell className="py-3">
+                      <UserCell name={row.name} email={row.email} />
+                    </TableCell>
+                    <TableCell className="py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="w-44">
+                          <RoleSelect
+                            value={role}
+                            onChange={(next) => onRoleChange(row, next)}
+                            disabled={solo || pending}
+                            ariaLabel={`Alterar papel de ${row.name}`}
+                          />
+                        </div>
+                        {solo && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span
+                                aria-label="Único administrador"
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-slate-700/60 text-slate-400"
+                              >
+                                <Lock className="h-3.5 w-3.5" />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent className="bg-slate-900 border-slate-700 text-white text-xs">
+                              Não é possível alterar — é o único administrador
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-xs text-slate-400">
+                      {formatRelativeTimePtBR(row.lastActiveAt)}
+                    </TableCell>
+                    <TableCell className="text-xs text-slate-400">
+                      {row.joinedVia === "domain" ? (
+                        <span className="inline-flex items-center gap-1.5">
+                          <Globe className="h-3.5 w-3.5 text-amber-300/70" />
+                          {emailDomain(row.email)}
+                        </span>
+                      ) : row.joinedVia === "invitation" ? (
+                        <span className="inline-flex items-center gap-1.5">
+                          <Mail className="h-3.5 w-3.5 text-slate-500" />
+                          {joinedViaLabel.invitation}
+                        </span>
+                      ) : (
+                        joinedViaLabel.manual
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                            aria-label={`Ações para ${row.name}`}
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          className="border-slate-700 bg-slate-900 text-white"
+                        >
+                          <DropdownMenuItem
+                            disabled
+                            className="text-slate-400"
+                          >
+                            <Eye className="mr-2 h-3.5 w-3.5" />
+                            Ver perfil
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => onMove(row)}
+                            className="focus:bg-slate-800"
+                          >
+                            <ArrowRightLeft className="mr-2 h-3.5 w-3.5" />
+                            Mover para outra organização
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator className="bg-slate-700/60" />
+                          <DropdownMenuItem
+                            onClick={() => onRemove(row)}
+                            disabled={solo}
+                            className="text-rose-300 focus:bg-rose-500/10 focus:text-rose-200"
+                          >
+                            <UserMinus className="mr-2 h-3.5 w-3.5" />
+                            Remover desta organização
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+        </TableBody>
+      </Table>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
@@ -1,16 +1,430 @@
-import { Users } from "lucide-react";
-import { EmptyState } from "@/components/admin/empty-state";
+"use client";
 
-/**
- * Placeholder owned by Agent B (members tab).
- * Lives here so the Membros tab does not 404 while the real page is wired.
- */
-export default function MembersTabPlaceholderPage() {
+import { useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ChevronDown,
+  FileSpreadsheet,
+  Link2,
+  Loader2,
+  RotateCw,
+  Search,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useGetV1OrganizationsIdMembers } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdMembers";
+import { usePutV1OrganizationsIdMembersUserid } from "@/kubb/hooks/organizationsHooks/usePutV1OrganizationsIdMembersUserid";
+import { useDeleteV1OrganizationsIdMembersUserid } from "@/kubb/hooks/organizationsHooks/useDeleteV1OrganizationsIdMembersUserid";
+import { useGetV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { EmptyState } from "@/components/admin/empty-state";
+import { LinkExistingUserDialog } from "@/components/admin/link-existing-user-dialog";
+import { MoveUserDialog } from "@/components/admin/move-user-dialog";
+import { CsvImportModal } from "@/components/admin/csv-import-modal";
+import { isAdminRole } from "@/components/admin/role-badge";
+import type { AdminRole } from "@/components/admin/role-badge";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { ApiError } from "@/lib/apiClient";
+import { cn } from "@/lib/utils";
+import { MembersTable, type MemberRow } from "./_components/members-table";
+
+type RoleFilter = "all" | AdminRole;
+
+const filterButtons: { id: RoleFilter; label: string }[] = [
+  { id: "all", label: "Todos" },
+  { id: "admin", label: "Administradores" },
+  { id: "coordinator", label: "Coordenadores" },
+  { id: "teacher", label: "Professores" },
+  { id: "student", label: "Alunos" },
+];
+
+export default function MembersTabPage() {
+  const params = useParams<{ id: string }>();
+  const orgId = params?.id ?? "";
+  const queryClient = useQueryClient();
+
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [csvOpen, setCsvOpen] = useState(false);
+  const [moveTarget, setMoveTarget] = useState<MemberRow | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<MemberRow | null>(null);
+
+  const { data: orgData } = useGetV1OrganizationsId(orgId, {
+    query: { enabled: orgId.length > 0 },
+  });
+  const orgName = orgData?.data?.name ?? "esta organização";
+
+  const queryParams = useMemo(() => {
+    const trimmed = debouncedSearch.trim();
+    return {
+      ...(trimmed.length > 0 ? { q: trimmed } : {}),
+      ...(roleFilter !== "all" ? { role: roleFilter } : {}),
+    };
+  }, [debouncedSearch, roleFilter]);
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  } = useGetV1OrganizationsIdMembers(orgId, queryParams, {
+    query: { enabled: orgId.length > 0 },
+  });
+
+  const rows = useMemo<MemberRow[]>(() => {
+    return (data?.data ?? []).map((m) => ({
+      id: m.id,
+      userId: m.userId,
+      name: m.name,
+      email: m.email,
+      role: m.role,
+      createdAt: m.createdAt,
+      lastActiveAt: m.lastActiveAt,
+      joinedVia: m.joinedVia,
+    }));
+  }, [data]);
+
+  const counts = useMemo(() => {
+    const base: Record<RoleFilter, number> = {
+      all: rows.length,
+      admin: 0,
+      coordinator: 0,
+      teacher: 0,
+      student: 0,
+    };
+    for (const row of rows) {
+      if (isAdminRole(row.role)) {
+        base[row.role] += 1;
+      }
+    }
+    return base;
+  }, [rows]);
+
+  // Solo-admin guard: backend doesn't paginate this list, so the response
+  // contains every member. When exactly one row has role === "admin", that
+  // row is locked.
+  const adminCountInResponse = counts.admin;
+  const isSoloAdmin = (row: MemberRow) =>
+    adminCountInResponse === 1 && row.role === "admin";
+
+  const updateRole = usePutV1OrganizationsIdMembersUserid({
+    mutation: {
+      onSuccess: () => {
+        toast.success("Papel atualizado");
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/:id/members" ||
+              first?.url === "/v1/users/"
+            );
+          },
+        });
+      },
+      onError: (err) => {
+        if (err instanceof ApiError && err.status === 409) {
+          toast.error(
+            "Não foi possível alterar — esta operação deixaria a organização sem administradores.",
+          );
+          return;
+        }
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao atualizar papel",
+        );
+      },
+    },
+  });
+
+  const removeMember = useDeleteV1OrganizationsIdMembersUserid({
+    mutation: {
+      onSuccess: () => {
+        toast.success("Membro removido da organização");
+        setRemoveTarget(null);
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/:id/members" ||
+              first?.url === "/v1/organizations/:id" ||
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/users/"
+            );
+          },
+        });
+      },
+      onError: (err) => {
+        if (err instanceof ApiError && err.status === 409) {
+          toast.error(
+            "Não é possível remover o único administrador da organização.",
+          );
+          return;
+        }
+        toast.error(
+          err instanceof Error ? err.message : "Erro ao remover membro",
+        );
+      },
+    },
+  });
+
+  const pendingRoleUserId = updateRole.isPending
+    ? (updateRole.variables as { userId?: string } | undefined)?.userId
+    : undefined;
+
+  const handleRoleChange = (row: MemberRow, role: AdminRole) => {
+    if (row.role === role) return;
+    updateRole.mutate({ id: orgId, userId: row.userId, data: { role } });
+  };
+
+  const handleRemoveConfirm = () => {
+    if (!removeTarget) return;
+    removeMember.mutate({ id: orgId, userId: removeTarget.userId });
+  };
+
+  const showSearchEmpty =
+    !isLoading &&
+    rows.length === 0 &&
+    (debouncedSearch.trim().length > 0 || roleFilter !== "all");
+
+  const showInitialEmpty =
+    !isLoading &&
+    !error &&
+    rows.length === 0 &&
+    debouncedSearch.trim().length === 0 &&
+    roleFilter === "all";
+
   return (
-    <EmptyState
-      icon={Users}
-      title="Em construção"
-      body="A aba de membros será entregue em breve pelo agente responsável."
-    />
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[240px] max-w-md">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar membros por nome ou email…"
+            className="bg-slate-900 border-slate-700 pl-9 pr-9 text-white placeholder:text-slate-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 hover:text-white"
+              aria-label="Limpar busca"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1 rounded-md border border-slate-700 bg-slate-900 p-1">
+          {filterButtons.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setRoleFilter(opt.id)}
+              className={cn(
+                "rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                roleFilter === opt.id
+                  ? "bg-slate-700 text-white"
+                  : "text-slate-400 hover:text-white",
+              )}
+            >
+              {opt.label}{" "}
+              <span className="text-slate-500">· {counts[opt.id]}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="ml-auto">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+              >
+                <UserPlus className="mr-1.5 h-4 w-4" />
+                Adicionar membro
+                <ChevronDown className="ml-1 h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="border-slate-700 bg-slate-900 text-white"
+            >
+              <DropdownMenuItem
+                onClick={() => setLinkOpen(true)}
+                className="focus:bg-slate-800"
+              >
+                <Link2 className="mr-2 h-3.5 w-3.5" />
+                <div className="flex flex-col items-start">
+                  <span className="text-sm">Vincular usuário existente</span>
+                  <span className="text-[11px] text-slate-400">
+                    Buscar em toda a plataforma
+                  </span>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setCsvOpen(true)}
+                className="focus:bg-slate-800"
+              >
+                <FileSpreadsheet className="mr-2 h-3.5 w-3.5" />
+                <div className="flex flex-col items-start">
+                  <span className="text-sm">Importar de CSV</span>
+                  <span className="text-[11px] text-slate-400">
+                    Adicionar vários de uma vez
+                  </span>
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-200">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" />
+            <span>
+              Não foi possível carregar os membros.{" "}
+              {error instanceof Error ? error.message : ""}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void refetch();
+            }}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Tentar novamente
+          </Button>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/40">
+          {showInitialEmpty ? (
+            <EmptyState
+              icon={Users}
+              title="Sem membros"
+              body="Esta organização ainda não tem membros."
+            />
+          ) : showSearchEmpty ? (
+            <EmptyState
+              icon={Users}
+              title="Nenhum membro corresponde"
+              body="Tente uma busca ou filtro de papel diferente."
+            />
+          ) : (
+            <>
+              <MembersTable
+                rows={rows}
+                isLoading={isLoading || (isFetching && rows.length === 0)}
+                isSoloAdmin={isSoloAdmin}
+                pendingRoleUserId={pendingRoleUserId}
+                onRoleChange={handleRoleChange}
+                onMove={setMoveTarget}
+                onRemove={setRemoveTarget}
+              />
+              {isFetching && rows.length > 0 && (
+                <div className="flex items-center justify-end gap-2 border-t border-slate-700/60 bg-slate-800/30 px-4 py-2 text-[11px] text-slate-500">
+                  <Loader2 className="h-3 w-3 animate-spin" /> atualizando…
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      <LinkExistingUserDialog
+        open={linkOpen}
+        onOpenChange={setLinkOpen}
+        organizationId={orgId}
+      />
+
+      <MoveUserDialog
+        open={!!moveTarget}
+        onOpenChange={(open) => {
+          if (!open) setMoveTarget(null);
+        }}
+        member={
+          moveTarget
+            ? {
+                userId: moveTarget.userId,
+                name: moveTarget.name,
+                email: moveTarget.email,
+                role: moveTarget.role,
+              }
+            : null
+        }
+        currentOrgId={orgId}
+        currentOrgName={orgName}
+      />
+
+      <CsvImportModal
+        open={csvOpen}
+        onOpenChange={setCsvOpen}
+        organizationId={orgId}
+      />
+
+      <AlertDialog
+        open={!!removeTarget}
+        onOpenChange={(open) => {
+          if (!open) setRemoveTarget(null);
+        }}
+      >
+        <AlertDialogContent className="bg-slate-900 border-slate-700 text-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover desta organização?</AlertDialogTitle>
+            <AlertDialogDescription className="text-slate-400">
+              {removeTarget
+                ? `${removeTarget.name} (${removeTarget.email}) perderá acesso a ${orgName}. Esta ação pode ser revertida vinculando o usuário novamente.`
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={removeMember.isPending}
+              className="bg-slate-800 text-white border-slate-700 hover:bg-slate-700"
+            >
+              Cancelar
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRemoveConfirm}
+              disabled={removeMember.isPending}
+              className="bg-rose-500 text-white hover:bg-rose-400"
+            >
+              {removeMember.isPending ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   );
 }

--- a/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
+++ b/apps/web/src/app/(inside)/admin/organizations/[id]/members/page.tsx
@@ -16,10 +16,18 @@ import {
   X,
 } from "lucide-react";
 import { toast } from "sonner";
-import { useGetV1OrganizationsIdMembers } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdMembers";
+import {
+  getV1OrganizationsIdMembersQueryKey,
+  useGetV1OrganizationsIdMembers,
+} from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdMembers";
 import { usePutV1OrganizationsIdMembersUserid } from "@/kubb/hooks/organizationsHooks/usePutV1OrganizationsIdMembersUserid";
 import { useDeleteV1OrganizationsIdMembersUserid } from "@/kubb/hooks/organizationsHooks/useDeleteV1OrganizationsIdMembersUserid";
-import { useGetV1OrganizationsId } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import {
+  getV1OrganizationsIdQueryKey,
+  useGetV1OrganizationsId,
+} from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { getV1OrganizationsQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
+import { getV1UsersQueryKey } from "@/kubb/hooks/usersHooks/useGetV1Users";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -136,13 +144,10 @@ export default function MembersTabPage() {
       onSuccess: () => {
         toast.success("Papel atualizado");
         void queryClient.invalidateQueries({
-          predicate: (query) => {
-            const first = query.queryKey[0] as { url?: string } | undefined;
-            return (
-              first?.url === "/v1/organizations/:id/members" ||
-              first?.url === "/v1/users/"
-            );
-          },
+          queryKey: getV1OrganizationsIdMembersQueryKey(orgId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [getV1UsersQueryKey({ q: "" })[0]],
         });
       },
       onError: (err) => {
@@ -165,15 +170,16 @@ export default function MembersTabPage() {
         toast.success("Membro removido da organização");
         setRemoveTarget(null);
         void queryClient.invalidateQueries({
-          predicate: (query) => {
-            const first = query.queryKey[0] as { url?: string } | undefined;
-            return (
-              first?.url === "/v1/organizations/:id/members" ||
-              first?.url === "/v1/organizations/:id" ||
-              first?.url === "/v1/organizations/" ||
-              first?.url === "/v1/users/"
-            );
-          },
+          queryKey: getV1OrganizationsIdMembersQueryKey(orgId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(orgId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsQueryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [getV1UsersQueryKey({ q: "" })[0]],
         });
       },
       onError: (err) => {

--- a/apps/web/src/app/(inside)/admin/users/page.tsx
+++ b/apps/web/src/app/(inside)/admin/users/page.tsx
@@ -73,8 +73,6 @@ export default function AdminUsersPage() {
     totalPages: 1,
   };
 
-  const platformAdminCount = rows.filter((u) => u.isPlatformAdmin).length;
-
   return (
     <div className="space-y-6">
       <div>
@@ -85,11 +83,7 @@ export default function AdminUsersPage() {
             <>
               {" "}
               · {pagination.total}{" "}
-              {pagination.total === 1 ? "usuário" : "usuários"} ·{" "}
-              {platformAdminCount}{" "}
-              {platformAdminCount === 1
-                ? "administrador da plataforma"
-                : "administradores da plataforma"}
+              {pagination.total === 1 ? "usuário" : "usuários"}
             </>
           ) : null}
         </p>

--- a/apps/web/src/app/(inside)/admin/users/page.tsx
+++ b/apps/web/src/app/(inside)/admin/users/page.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Eye,
+  Loader2,
+  MoreHorizontal,
+  RotateCw,
+  Search,
+  Users as UsersIcon,
+  X,
+} from "lucide-react";
+import { useGetV1Users } from "@/kubb/hooks/usersHooks/useGetV1Users";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { EmptyState } from "@/components/admin/empty-state";
+import { Pager } from "@/components/admin/pager";
+import { AvatarSquare } from "@/components/admin/avatar-square";
+import { RoleBadge, isAdminRole } from "@/components/admin/role-badge";
+import { AdminToggle } from "@/components/admin/admin-toggle";
+import {
+  ToggleAdminDialog,
+  type ToggleAdminTarget,
+} from "@/components/admin/toggle-admin-dialog";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useUser } from "@/contexts/UserContext";
+
+const PER_PAGE = 20;
+
+export default function AdminUsersPage() {
+  const { user: me } = useUser();
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const [page, setPage] = useState(1);
+  const [toggleTarget, setToggleTarget] = useState<ToggleAdminTarget | null>(
+    null,
+  );
+
+  const trimmed = debouncedSearch.trim();
+  const queryEnabled = trimmed.length >= 2;
+
+  const params = useMemo(
+    () => ({ q: trimmed, page, perPage: PER_PAGE }),
+    [trimmed, page],
+  );
+
+  const { data, isLoading, isFetching, error, refetch } = useGetV1Users(
+    params,
+    { query: { enabled: queryEnabled } },
+  );
+
+  const rows = data?.data ?? [];
+  const pagination = data?.pagination ?? {
+    total: 0,
+    page: 1,
+    perPage: PER_PAGE,
+    totalPages: 1,
+  };
+
+  const platformAdminCount = rows.filter((u) => u.isPlatformAdmin).length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-white">Usuários</h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Buscar em toda a plataforma
+          {queryEnabled && data ? (
+            <>
+              {" "}
+              · {pagination.total}{" "}
+              {pagination.total === 1 ? "usuário" : "usuários"} ·{" "}
+              {platformAdminCount}{" "}
+              {platformAdminCount === 1
+                ? "administrador da plataforma"
+                : "administradores da plataforma"}
+            </>
+          ) : null}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[280px] max-w-xl">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+          <Input
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            placeholder="Buscar por nome ou e-mail…"
+            autoFocus
+            className="bg-slate-900 border-slate-700 pl-9 pr-9 text-white placeholder:text-slate-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => {
+                setSearch("");
+                setPage(1);
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 hover:text-white"
+              aria-label="Limpar busca"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        {!queryEnabled && search.length > 0 && (
+          <span className="text-xs text-slate-500">
+            Digite ao menos 2 caracteres
+          </span>
+        )}
+      </div>
+
+      {error ? (
+        <div className="flex items-center justify-between gap-3 rounded-lg border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-200">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" />
+            <span>
+              Não foi possível carregar usuários.{" "}
+              {error instanceof Error ? error.message : ""}
+            </span>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void refetch();
+            }}
+          >
+            <RotateCw className="mr-1.5 h-3.5 w-3.5" />
+            Tentar novamente
+          </Button>
+        </div>
+      ) : !queryEnabled ? (
+        <div className="overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/40">
+          <EmptyState
+            icon={Search}
+            title="Comece digitando para buscar usuários"
+            body="A busca usa nome ou e-mail. São necessários ao menos 2 caracteres."
+          />
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/40">
+          {!isLoading && rows.length === 0 ? (
+            <EmptyState
+              icon={UsersIcon}
+              title="Nenhum usuário encontrado"
+              body={`Nada corresponde a "${trimmed}".`}
+            />
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-slate-700/60 hover:bg-transparent">
+                    <TableHead className="text-slate-400">Usuário</TableHead>
+                    <TableHead className="text-slate-400">
+                      Organizações
+                    </TableHead>
+                    <TableHead className="text-slate-400">
+                      Admin da Plataforma
+                    </TableHead>
+                    <TableHead className="text-right text-slate-400">
+                      Ações
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoading || (isFetching && rows.length === 0)
+                    ? Array.from({ length: 6 }).map((_, i) => (
+                        <TableRow
+                          key={`sk-${i}`}
+                          className="border-slate-700/60"
+                        >
+                          <TableCell>
+                            <div className="flex items-center gap-3">
+                              <Skeleton className="h-10 w-10 rounded-lg bg-slate-800" />
+                              <div className="space-y-1.5">
+                                <Skeleton className="h-3 w-40 bg-slate-800" />
+                                <Skeleton className="h-2.5 w-32 bg-slate-800" />
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-48 bg-slate-800" />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton className="h-4 w-9 bg-slate-800" />
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Skeleton className="ml-auto h-7 w-7 bg-slate-800" />
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    : rows.map((u) => {
+                        const isMe = me?.id === u.id;
+                        return (
+                          <TableRow
+                            key={u.id}
+                            className="border-slate-700/60 hover:bg-slate-800/30"
+                          >
+                            <TableCell className="py-3">
+                              <div className="flex items-center gap-3 min-w-0">
+                                <AvatarSquare name={u.name} size="md" />
+                                <div className="flex min-w-0 flex-col">
+                                  <span className="flex items-center gap-2 truncate text-sm font-medium text-white">
+                                    {u.name}
+                                    {isMe && (
+                                      <span className="rounded-full border border-slate-600/60 bg-slate-800/70 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-300">
+                                        Você
+                                      </span>
+                                    )}
+                                  </span>
+                                  <span className="truncate text-xs text-slate-400">
+                                    {u.email}
+                                  </span>
+                                </div>
+                              </div>
+                            </TableCell>
+                            <TableCell className="py-3">
+                              {u.memberships.length === 0 ? (
+                                <span className="text-xs text-slate-500">
+                                  — Sem organizações —
+                                </span>
+                              ) : (
+                                <div className="flex flex-wrap gap-1.5">
+                                  {u.memberships.map((m) => {
+                                    const role = isAdminRole(m.role)
+                                      ? m.role
+                                      : null;
+                                    return (
+                                      <span
+                                        key={`${u.id}-${m.organizationId}`}
+                                        className="inline-flex items-center gap-1.5 rounded-full border border-slate-700/60 bg-slate-950/50 px-2 py-0.5 text-[11px]"
+                                      >
+                                        <span className="text-white">
+                                          {m.organizationName}
+                                        </span>
+                                        {role && <RoleBadge role={role} />}
+                                      </span>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <AdminToggle
+                                checked={u.isPlatformAdmin}
+                                onClick={() =>
+                                  setToggleTarget({
+                                    id: u.id,
+                                    name: u.name,
+                                    email: u.email,
+                                    isPlatformAdmin: u.isPlatformAdmin,
+                                  })
+                                }
+                                ariaLabel={`Alternar Admin da Plataforma para ${u.name}`}
+                              />
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    type="button"
+                                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                                    aria-label={`Ações para ${u.name}`}
+                                  >
+                                    <MoreHorizontal className="h-4 w-4" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                  align="end"
+                                  className="border-slate-700 bg-slate-900 text-white"
+                                >
+                                  <DropdownMenuItem
+                                    disabled
+                                    className="text-slate-400"
+                                  >
+                                    <Eye className="mr-2 h-3.5 w-3.5" />
+                                    Ver perfil
+                                  </DropdownMenuItem>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                </TableBody>
+              </Table>
+              {isFetching && rows.length > 0 && (
+                <div className="flex items-center justify-end gap-2 border-t border-slate-700/60 bg-slate-800/30 px-4 py-2 text-[11px] text-slate-500">
+                  <Loader2 className="h-3 w-3 animate-spin" /> atualizando…
+                </div>
+              )}
+              <Pager
+                page={pagination.page}
+                perPage={pagination.perPage}
+                total={pagination.total}
+                totalPages={pagination.totalPages}
+                onPageChange={setPage}
+              />
+            </>
+          )}
+        </div>
+      )}
+
+      <ToggleAdminDialog
+        open={!!toggleTarget}
+        onOpenChange={(open) => {
+          if (!open) setToggleTarget(null);
+        }}
+        target={toggleTarget}
+        currentUserId={me?.id ?? ""}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/admin-toggle.tsx
+++ b/apps/web/src/components/admin/admin-toggle.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface AdminToggleProps {
+  checked: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  ariaLabel: string;
+  className?: string;
+}
+
+/**
+ * Small accessible on/off toggle used by the admin pages (e.g. platform admin
+ * row toggle on /admin/users).
+ */
+export function AdminToggle({
+  checked,
+  onClick,
+  disabled,
+  ariaLabel,
+  className,
+}: AdminToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/40",
+        checked
+          ? "border-amber-400/40 bg-amber-500/30"
+          : "border-slate-600/60 bg-slate-700/40",
+        disabled && "cursor-not-allowed opacity-60",
+        className,
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform",
+          checked ? "translate-x-4" : "translate-x-1",
+        )}
+      />
+    </button>
+  );
+}

--- a/apps/web/src/components/admin/csv-import-modal.tsx
+++ b/apps/web/src/components/admin/csv-import-modal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface CsvImportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+}
+
+/**
+ * Stub owned by Agent C. Kept here so Agent B can wire the trigger from the
+ * members tab. Agent C will replace this file with the real implementation
+ * keeping the same prop shape.
+ */
+export function CsvImportModal({ open, onOpenChange }: CsvImportModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Importar de CSV</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Em breve.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/link-existing-user-dialog.tsx
+++ b/apps/web/src/components/admin/link-existing-user-dialog.tsx
@@ -17,6 +17,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useGetV1Users } from "@/kubb/hooks/usersHooks/useGetV1Users";
 import { usePostV1OrganizationsIdMembers } from "@/kubb/hooks/organizationsHooks/usePostV1OrganizationsIdMembers";
+import { getV1OrganizationsIdMembersQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdMembers";
+import { getV1OrganizationsIdQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { getV1OrganizationsQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { cn } from "@/lib/utils";
 import { ApiError } from "@/lib/apiClient";
@@ -77,14 +80,13 @@ export function LinkExistingUserDialog({
       onSuccess: () => {
         toast.success("Usuário vinculado à organização");
         void queryClient.invalidateQueries({
-          predicate: (query) => {
-            const first = query.queryKey[0] as { url?: string } | undefined;
-            return (
-              first?.url === "/v1/organizations/:id/members" ||
-              first?.url === "/v1/organizations/:id" ||
-              first?.url === "/v1/organizations/"
-            );
-          },
+          queryKey: getV1OrganizationsIdMembersQueryKey(organizationId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(organizationId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsQueryKey(),
         });
         onOpenChange(false);
       },

--- a/apps/web/src/components/admin/link-existing-user-dialog.tsx
+++ b/apps/web/src/components/admin/link-existing-user-dialog.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Check, Link2, Loader2, Search, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useGetV1Users } from "@/kubb/hooks/usersHooks/useGetV1Users";
+import { usePostV1OrganizationsIdMembers } from "@/kubb/hooks/organizationsHooks/usePostV1OrganizationsIdMembers";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { cn } from "@/lib/utils";
+import { ApiError } from "@/lib/apiClient";
+import { AvatarSquare } from "./avatar-square";
+import { RoleSelect } from "./role-select";
+import type { AdminRole } from "./role-badge";
+
+interface LinkExistingUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  organizationId: string;
+}
+
+interface PickedUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export function LinkExistingUserDialog({
+  open,
+  onOpenChange,
+  organizationId,
+}: LinkExistingUserDialogProps) {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const [picked, setPicked] = useState<PickedUser | null>(null);
+  const [role, setRole] = useState<AdminRole>("teacher");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      setPicked(null);
+      setRole("teacher");
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  const trimmed = debouncedSearch.trim();
+  const queryEnabled = trimmed.length >= 2;
+
+  const { data, isLoading, isFetching, error } = useGetV1Users(
+    { q: trimmed },
+    { query: { enabled: queryEnabled } },
+  );
+
+  const candidates = useMemo(() => {
+    const list = data?.data ?? [];
+    return list.filter(
+      (u) => !u.memberships.some((m) => m.organizationId === organizationId),
+    );
+  }, [data, organizationId]);
+
+  const mutation = usePostV1OrganizationsIdMembers({
+    mutation: {
+      onSuccess: () => {
+        toast.success("Usuário vinculado à organização");
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/:id/members" ||
+              first?.url === "/v1/organizations/:id" ||
+              first?.url === "/v1/organizations/"
+            );
+          },
+        });
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        if (err instanceof ApiError) {
+          if (err.status === 409) {
+            setErrorMessage("Este usuário já é membro da organização.");
+            return;
+          }
+          if (err.status === 404) {
+            setErrorMessage("Usuário não encontrado.");
+            return;
+          }
+          setErrorMessage(err.message);
+          return;
+        }
+        setErrorMessage(
+          err instanceof Error ? err.message : "Erro ao vincular usuário",
+        );
+      },
+    },
+  });
+
+  const handleConfirm = () => {
+    if (!picked) return;
+    setErrorMessage(null);
+    mutation.mutate({
+      id: organizationId,
+      data: { email: picked.email, role },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Vincular usuário existente</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Pesquise pessoas em toda a plataforma e adicione à organização.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="link-user-search" className="text-slate-300 text-xs">
+              Buscar usuário
+            </Label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+              <Input
+                id="link-user-search"
+                value={search}
+                onChange={(e) => {
+                  setSearch(e.target.value);
+                  setPicked(null);
+                }}
+                placeholder="Nome ou e-mail…"
+                autoFocus
+                className="bg-slate-950/40 border-slate-700 pl-9 pr-9 text-white placeholder:text-slate-500"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearch("");
+                    setPicked(null);
+                  }}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-slate-500 hover:text-white"
+                  aria-label="Limpar busca"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+            {!queryEnabled && (
+              <p className="text-[11px] text-slate-500">
+                Digite ao menos 2 caracteres para iniciar a busca.
+              </p>
+            )}
+          </div>
+
+          <div className="max-h-64 overflow-y-auto rounded-md border border-slate-700/60 bg-slate-950/40">
+            {!queryEnabled ? (
+              <div className="px-4 py-6 text-center text-xs text-slate-500">
+                Use o campo acima para pesquisar usuários.
+              </div>
+            ) : isLoading || isFetching ? (
+              <div className="flex items-center justify-center px-4 py-6 text-xs text-slate-400">
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                Buscando…
+              </div>
+            ) : error ? (
+              <div className="px-4 py-6 text-center text-xs text-rose-300">
+                Não foi possível buscar usuários.
+              </div>
+            ) : candidates.length === 0 ? (
+              <div className="px-4 py-6 text-center text-xs text-slate-500">
+                Nenhum usuário disponível para vincular.
+              </div>
+            ) : (
+              <ul className="divide-y divide-slate-700/60">
+                {candidates.map((u) => {
+                  const isPicked = picked?.id === u.id;
+                  return (
+                    <li key={u.id}>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setPicked({ id: u.id, name: u.name, email: u.email })
+                        }
+                        className={cn(
+                          "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors",
+                          isPicked
+                            ? "bg-amber-500/10"
+                            : "hover:bg-slate-800/50",
+                        )}
+                      >
+                        <AvatarSquare name={u.name} size="sm" />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-sm font-medium text-white">
+                            {u.name}
+                          </div>
+                          <div className="truncate text-xs text-slate-400">
+                            {u.email}
+                          </div>
+                        </div>
+                        <span className="shrink-0 text-[11px] text-slate-500">
+                          {u.memberships.length}{" "}
+                          {u.memberships.length === 1
+                            ? "organização"
+                            : "organizações"}
+                        </span>
+                        {isPicked && (
+                          <Check className="h-4 w-4 shrink-0 text-amber-300" />
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-slate-300 text-xs">
+              Papel na organização
+            </Label>
+            <RoleSelect value={role} onChange={setRole} />
+          </div>
+
+          {errorMessage && (
+            <div className="flex items-start gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 p-2.5 text-xs text-rose-200">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{errorMessage}</span>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!picked || mutation.isPending}
+            className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Link2 className="h-4 w-4" />
+            )}
+            Vincular à organização
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/move-user-dialog.tsx
+++ b/apps/web/src/components/admin/move-user-dialog.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, ArrowRightLeft, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useGetV1Organizations } from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
+import { usePostV1OrganizationsIdMembersUseridMove } from "@/kubb/hooks/organizationsHooks/usePostV1OrganizationsIdMembersUseridMove";
+import { ApiError } from "@/lib/apiClient";
+import { AvatarSquare } from "./avatar-square";
+import { RoleBadge, isAdminRole } from "./role-badge";
+import { RoleSelect } from "./role-select";
+import type { AdminRole } from "./role-badge";
+
+export interface MoveUserMember {
+  userId: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+interface MoveUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  member: MoveUserMember | null;
+  currentOrgId: string;
+  currentOrgName: string;
+}
+
+export function MoveUserDialog({
+  open,
+  onOpenChange,
+  member,
+  currentOrgId,
+  currentOrgName,
+}: MoveUserDialogProps) {
+  const queryClient = useQueryClient();
+  const [destOrgId, setDestOrgId] = useState("");
+  const [role, setRole] = useState<AdminRole>("teacher");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setDestOrgId("");
+      setRole("teacher");
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  const { data: orgsData, isLoading: orgsLoading } = useGetV1Organizations(
+    { page: 1, perPage: 100, includeInactive: false },
+    { query: { enabled: open } },
+  );
+
+  const otherOrgs = useMemo(() => {
+    const list = orgsData?.data ?? [];
+    return list.filter((o) => o.id !== currentOrgId && o.isActive);
+  }, [orgsData, currentOrgId]);
+
+  const mutation = usePostV1OrganizationsIdMembersUseridMove({
+    mutation: {
+      onSuccess: () => {
+        toast.success("Usuário movido para a nova organização");
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return (
+              first?.url === "/v1/organizations/:id/members" ||
+              first?.url === "/v1/organizations/:id" ||
+              first?.url === "/v1/organizations/" ||
+              first?.url === "/v1/users/"
+            );
+          },
+        });
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        if (err instanceof ApiError) {
+          if (err.status === 409) {
+            setErrorMessage(
+              "Não foi possível mover: o usuário é o único administrador da organização atual.",
+            );
+            return;
+          }
+          if (err.status === 404) {
+            setErrorMessage("Organização ou usuário não encontrado.");
+            return;
+          }
+          setErrorMessage(err.message);
+          return;
+        }
+        setErrorMessage(
+          err instanceof Error ? err.message : "Erro ao mover usuário",
+        );
+      },
+    },
+  });
+
+  const handleConfirm = () => {
+    if (!member || !destOrgId) return;
+    setErrorMessage(null);
+    mutation.mutate({
+      id: currentOrgId,
+      userId: member.userId,
+      data: { toOrganizationId: destOrgId, newRole: role },
+    });
+  };
+
+  const memberRole: AdminRole | null = member && isAdminRole(member.role) ? member.role : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Mover para outra organização</DialogTitle>
+          <DialogDescription className="text-slate-400">
+            Move o usuário de {currentOrgName} para outra organização ativa.
+          </DialogDescription>
+        </DialogHeader>
+
+        {member && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-3 rounded-md border border-slate-700/60 bg-slate-950/40 p-3">
+              <AvatarSquare name={member.name} size="md" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-white">
+                  {member.name}
+                </div>
+                <div className="truncate text-xs text-slate-400">
+                  {member.email}
+                </div>
+              </div>
+              {memberRole && <RoleBadge role={memberRole} />}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-slate-300 text-xs">
+                Organização de destino
+              </Label>
+              <Select
+                value={destOrgId}
+                onValueChange={setDestOrgId}
+                disabled={orgsLoading || otherOrgs.length === 0}
+              >
+                <SelectTrigger className="border-slate-700 bg-slate-900/60 text-white">
+                  <SelectValue
+                    placeholder={
+                      orgsLoading
+                        ? "Carregando organizações…"
+                        : otherOrgs.length === 0
+                          ? "Sem outras organizações ativas"
+                          : "Selecione uma organização…"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-900 border-slate-700 text-white">
+                  {otherOrgs.map((o) => (
+                    <SelectItem
+                      key={o.id}
+                      value={o.id}
+                      className="text-white focus:bg-slate-800 focus:text-white"
+                    >
+                      {o.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label className="text-slate-300 text-xs">
+                Papel na nova organização
+              </Label>
+              <RoleSelect value={role} onChange={setRole} />
+            </div>
+
+            <div className="flex gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="space-y-1">
+                <p className="font-medium">
+                  O usuário perderá acesso a {currentOrgName}.
+                </p>
+                <p className="text-amber-200/80">
+                  Matrículas em turmas, submissões e histórico de chat ficam
+                  arquivados na organização atual (não são excluídos).
+                </p>
+              </div>
+            </div>
+
+            {errorMessage && (
+              <div className="flex items-start gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 p-2.5 text-xs text-rose-200">
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>{errorMessage}</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!destOrgId || mutation.isPending}
+            className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ArrowRightLeft className="h-4 w-4" />
+            )}
+            Mover usuário
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/move-user-dialog.tsx
+++ b/apps/web/src/components/admin/move-user-dialog.tsx
@@ -21,8 +21,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useGetV1Organizations } from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
+import {
+  getV1OrganizationsQueryKey,
+  useGetV1Organizations,
+} from "@/kubb/hooks/organizationsHooks/useGetV1Organizations";
 import { usePostV1OrganizationsIdMembersUseridMove } from "@/kubb/hooks/organizationsHooks/usePostV1OrganizationsIdMembersUseridMove";
+import { getV1OrganizationsIdMembersQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsIdMembers";
+import { getV1OrganizationsIdQueryKey } from "@/kubb/hooks/organizationsHooks/useGetV1OrganizationsId";
+import { getV1UsersQueryKey } from "@/kubb/hooks/usersHooks/useGetV1Users";
 import { ApiError } from "@/lib/apiClient";
 import { AvatarSquare } from "./avatar-square";
 import { RoleBadge, isAdminRole } from "./role-badge";
@@ -76,18 +82,27 @@ export function MoveUserDialog({
 
   const mutation = usePostV1OrganizationsIdMembersUseridMove({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (_res, variables) => {
         toast.success("Usuário movido para a nova organização");
         void queryClient.invalidateQueries({
-          predicate: (query) => {
-            const first = query.queryKey[0] as { url?: string } | undefined;
-            return (
-              first?.url === "/v1/organizations/:id/members" ||
-              first?.url === "/v1/organizations/:id" ||
-              first?.url === "/v1/organizations/" ||
-              first?.url === "/v1/users/"
-            );
-          },
+          queryKey: getV1OrganizationsIdMembersQueryKey(currentOrgId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdMembersQueryKey(
+            variables.data.toOrganizationId,
+          ),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(currentOrgId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsIdQueryKey(variables.data.toOrganizationId),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1OrganizationsQueryKey(),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: [getV1UsersQueryKey({ q: "" })[0]],
         });
         onOpenChange(false);
       },

--- a/apps/web/src/components/admin/role-select.tsx
+++ b/apps/web/src/components/admin/role-select.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type { AdminRole } from "./role-badge";
+
+interface RoleSelectProps {
+  value: AdminRole;
+  onChange: (role: AdminRole) => void;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName?: string;
+  ariaLabel?: string;
+}
+
+const options: { value: AdminRole; label: string }[] = [
+  { value: "student", label: "Aluno" },
+  { value: "teacher", label: "Professor" },
+  { value: "coordinator", label: "Coordenador" },
+  { value: "admin", label: "Administrador" },
+];
+
+export function RoleSelect({
+  value,
+  onChange,
+  disabled,
+  className,
+  triggerClassName,
+  ariaLabel,
+}: RoleSelectProps) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => onChange(next as AdminRole)}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        aria-label={ariaLabel ?? "Selecionar papel"}
+        className={cn(
+          "h-9 border-slate-700 bg-slate-900/60 text-white data-[state=open]:bg-slate-900",
+          triggerClassName,
+          className,
+        )}
+      >
+        <SelectValue placeholder="Selecionar…" />
+      </SelectTrigger>
+      <SelectContent className="bg-slate-900 border-slate-700 text-white">
+        {options.map((opt) => (
+          <SelectItem
+            key={opt.value}
+            value={opt.value}
+            className="text-white focus:bg-slate-800 focus:text-white"
+          >
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+export const adminRoleOptions = options;

--- a/apps/web/src/components/admin/toggle-admin-dialog.tsx
+++ b/apps/web/src/components/admin/toggle-admin-dialog.tsx
@@ -21,6 +21,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { ApiError } from "@/lib/apiClient";
 import { usePatchV1UsersIdPlatformAdmin } from "@/kubb/hooks/usersHooks/usePatchV1UsersIdPlatformAdmin";
+import { getV1UsersQueryKey } from "@/kubb/hooks/usersHooks/useGetV1Users";
+import { getV1UsersMeQueryKey } from "@/kubb/hooks/usersHooks/useGetV1UsersMe";
 import { AvatarSquare } from "./avatar-square";
 
 export interface ToggleAdminTarget {
@@ -63,10 +65,10 @@ export function ToggleAdminDialog({
             : "Usuário promovido a Administrador",
         );
         void queryClient.invalidateQueries({
-          predicate: (query) => {
-            const first = query.queryKey[0] as { url?: string } | undefined;
-            return first?.url === "/v1/users/" || first?.url === "/v1/users/me";
-          },
+          queryKey: [getV1UsersQueryKey({ q: "" })[0]],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: getV1UsersMeQueryKey(),
         });
         onOpenChange(false);
       },

--- a/apps/web/src/components/admin/toggle-admin-dialog.tsx
+++ b/apps/web/src/components/admin/toggle-admin-dialog.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Loader2,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldOff,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/apiClient";
+import { usePatchV1UsersIdPlatformAdmin } from "@/kubb/hooks/usersHooks/usePatchV1UsersIdPlatformAdmin";
+import { AvatarSquare } from "./avatar-square";
+
+export interface ToggleAdminTarget {
+  id: string;
+  name: string;
+  email: string;
+  isPlatformAdmin: boolean;
+}
+
+interface ToggleAdminDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  target: ToggleAdminTarget | null;
+  currentUserId: string;
+}
+
+export function ToggleAdminDialog({
+  open,
+  onOpenChange,
+  target,
+  currentUserId,
+}: ToggleAdminDialogProps) {
+  const queryClient = useQueryClient();
+  const [soloLock, setSoloLock] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSoloLock(false);
+      setErrorMessage(null);
+    }
+  }, [open, target?.id]);
+
+  const mutation = usePatchV1UsersIdPlatformAdmin({
+    mutation: {
+      onSuccess: () => {
+        toast.success(
+          target?.isPlatformAdmin
+            ? "Permissão de Administrador removida"
+            : "Usuário promovido a Administrador",
+        );
+        void queryClient.invalidateQueries({
+          predicate: (query) => {
+            const first = query.queryKey[0] as { url?: string } | undefined;
+            return first?.url === "/v1/users/" || first?.url === "/v1/users/me";
+          },
+        });
+        onOpenChange(false);
+      },
+      onError: (err) => {
+        if (err instanceof ApiError && err.status === 409) {
+          // Backend blocks the only platform admin from demoting itself.
+          setSoloLock(true);
+          setErrorMessage(null);
+          return;
+        }
+        setErrorMessage(
+          err instanceof Error ? err.message : "Erro ao atualizar permissão",
+        );
+      },
+    },
+  });
+
+  if (!target) return null;
+
+  const promoting = !target.isPlatformAdmin;
+  const isSelf = target.id === currentUserId;
+
+  if (soloLock) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              Você é o único Administrador da Plataforma
+            </DialogTitle>
+            <DialogDescription className="text-slate-400">
+              Não é possível remover sua própria permissão enquanto você for o
+              único administrador.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col items-center gap-4 py-2 text-center">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-rose-500/30 bg-rose-500/10 text-rose-300">
+              <ShieldAlert className="h-6 w-6" />
+            </div>
+            <p className="max-w-sm text-sm text-slate-300">
+              Promova outro usuário a Administrador da Plataforma primeiro.
+              Depois disso você poderá rebaixar a si mesmo.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="bg-amber-500 text-slate-900 hover:bg-amber-400"
+            >
+              Entendi
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const handleConfirm = () => {
+    setErrorMessage(null);
+    mutation.mutate({
+      id: target.id,
+      data: { isPlatformAdmin: !target.isPlatformAdmin },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-slate-900 border-slate-700 text-white sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {promoting
+              ? "Promover a Administrador da Plataforma?"
+              : "Remover Administrador da Plataforma?"}
+          </DialogTitle>
+          <DialogDescription className="text-slate-400">
+            {promoting
+              ? "Conceda apenas a equipe TACO ou operadores de confiança."
+              : "A permissão será removida e as sessões ativas serão revogadas."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 rounded-md border border-slate-700/60 bg-slate-950/40 p-3">
+            <AvatarSquare name={target.name} size="md" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-medium text-white">
+                {target.name}
+              </div>
+              <div className="truncate text-xs text-slate-400">
+                {target.email}
+              </div>
+            </div>
+          </div>
+
+          {promoting ? (
+            <div className="flex gap-3 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Administradores da Plataforma podem{" "}
+                <strong className="text-amber-100">
+                  criar e excluir organizações
+                </strong>
+                ,{" "}
+                <strong className="text-amber-100">
+                  acessar dados de qualquer usuário
+                </strong>{" "}
+                e operar fora do escopo de organizações.
+              </p>
+            </div>
+          ) : (
+            <div className="flex gap-3 rounded-md border border-sky-500/30 bg-sky-500/10 p-3 text-xs text-sky-200">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                {target.name} perderá acesso a <code>/admin</code> e às
+                ferramentas globais. As organizações onde {target.name} é
+                membro não são afetadas. As sessões ativas serão revogadas — o
+                usuário precisará entrar novamente.
+                {isSelf && (
+                  <span className="mt-1 block text-sky-100">
+                    Você será desconectado em seguida.
+                  </span>
+                )}
+              </p>
+            </div>
+          )}
+
+          {errorMessage && (
+            <div className="flex items-start gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 p-2.5 text-xs text-rose-200">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{errorMessage}</span>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={mutation.isPending}
+            className={
+              promoting
+                ? "bg-amber-500 text-slate-900 hover:bg-amber-400"
+                : "border border-rose-500/40 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20"
+            }
+          >
+            {mutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : promoting ? (
+              <ShieldCheck className="h-4 w-4" />
+            ) : (
+              <ShieldOff className="h-4 w-4" />
+            )}
+            {promoting ? "Sim, promover" : "Sim, remover"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -1,0 +1,41 @@
+const formatter = new Intl.RelativeTimeFormat("pt-BR", { numeric: "auto" });
+
+interface Threshold {
+  unit: Intl.RelativeTimeFormatUnit;
+  amount: number;
+}
+
+const thresholds: Threshold[] = [
+  { unit: "year", amount: 60 * 60 * 24 * 365 },
+  { unit: "month", amount: 60 * 60 * 24 * 30 },
+  { unit: "week", amount: 60 * 60 * 24 * 7 },
+  { unit: "day", amount: 60 * 60 * 24 },
+  { unit: "hour", amount: 60 * 60 },
+  { unit: "minute", amount: 60 },
+];
+
+/**
+ * Formats a timestamp (or ISO string) as a Brazilian Portuguese relative time
+ * label (e.g. "há 3 dias", "agora", "há 2 h"). Returns "Nunca" when the value
+ * is null/undefined.
+ */
+export function formatRelativeTimePtBR(value: string | Date | null | undefined): string {
+  if (value === null || value === undefined) return "Nunca";
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+
+  const diffSeconds = Math.round((date.getTime() - Date.now()) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+
+  if (absSeconds < 45) return "agora";
+
+  for (const { unit, amount } of thresholds) {
+    if (absSeconds >= amount) {
+      const value = Math.round(diffSeconds / amount);
+      return formatter.format(value, unit);
+    }
+  }
+
+  return formatter.format(diffSeconds, "second");
+}


### PR DESCRIPTION
## Summary
Adds members tab content and the `/admin/users` page, plus 3 modals (Link existing user, Move user between orgs, Toggle platform admin). Closes #63 (frontend portion). Stacks on Agent A's shell-orgs branch.

## What was replaced
- `members/page.tsx` placeholder → real page with search, role-segmented filter, role inline edit, last-admin lock and remove confirmation

## What was created
- `app/(inside)/admin/users/page.tsx` — global users search with debounced query (min 2 chars), pagination, org pills, platform-admin toggle column
- `components/admin/link-existing-user-dialog.tsx` — search platform users, hide existing org members, pick a role and submit
- `components/admin/move-user-dialog.tsx` — move user across active orgs with role select and inline 409 surface
- `components/admin/toggle-admin-dialog.tsx` — promote/demote dialog with three states (promote / demote / solo-admin lock triggered from backend 409)
- `components/admin/csv-import-modal.tsx` — STUB owned by Agent C (will be replaced)
- `components/admin/role-select.tsx`, `components/admin/admin-toggle.tsx` — small admin primitives reused by the new pages
- `lib/relative-time.ts` — pt-BR `Intl.RelativeTimeFormat` helper for "última atividade"
- `app/(inside)/admin/organizations/[id]/members/_components/members-table.tsx`

## Decisions worth noting
- Backend's `GET /v1/organizations/:id/members` is **not** paginated, so the page does not paginate either. The role-filter counts and solo-admin guard are computed from the full response. The plan's "Pager" call-out was relaxed accordingly.
- Solo-admin lock for the row uses the response's admin count. The remove + role mutations also surface backend 409s as user-friendly toasts.
- Solo-platform-admin lock is detected reactively from the backend's 409 response inside `ToggleAdminDialog` — no pre-flight count query (the platform users endpoint requires `q.length >= 2`, so a count query would be awkward).
- No shadcn Switch in this repo — built a tiny `AdminToggle` (button with `role="switch"`) instead.
- "Ver perfil" and "Impersonar" actions stay disabled/hidden per the plan's decisions.

## Test plan
- [ ] Sign in as platform admin and visit `/admin/organizations/<orgId>/members`
- [ ] Members table loads with last-active formatted in pt-BR (e.g. "há 3 dias")
- [ ] Inline role change persists and shows toast
- [ ] Search debounces, role filter updates counts
- [ ] Last-admin row shows lock icon + tooltip; role select and remove are disabled
- [ ] "Adicionar membro" dropdown shows; "Vincular usuário existente" opens dialog with debounced search
- [ ] Pick a user, select role, submit → success toast + dialog closes + list refreshes
- [ ] "Mover para outra organização" via row action → modal works; trying to move the only admin shows inline 409 message
- [ ] "Remover desta organização" → AlertDialog confirms → success
- [ ] `/admin/users` shows initial empty state ("Comece digitando para buscar usuários")
- [ ] Search "ed" → results render with org pills
- [ ] Toggle Platform Admin opens dialog; promote / demote both work and refetch
- [ ] Self-demote when sole admin → backend returns 409 → dialog switches to solo-lock variant

## Verification
- `npx tsc --noEmit` for `apps/web` — no new errors (pre-existing errors unrelated to this PR: missing `@types/node`, `Property 'organization'` in `UserContext`)
- `next build` from this worktree fails to install `@types/node` because the worktree lacks workspace-resolved deps — this is environmental, the source compiles cleanly. Reviewers should run the build from the integration branch.

## Notes
- All copy in pt-BR, kubb-generated hooks throughout, no `as any`
- Reuses Agent A's primitives: `UserCell`, `OrgCell`, `AvatarSquare`, `EmptyState`, `Pager`, `RoleBadge`, `useDebouncedValue`
- CSV modal is a stub at the agreed path/props for Agent C to replace