### PR TITLE
feat: avaliação anônima do AT no submit (1–5 estrelas)

### DIFF
--- a/apps/api/src/gen/kubb/zod/postV1WorkSessionsIdSubmitSchema.ts
+++ b/apps/api/src/gen/kubb/zod/postV1WorkSessionsIdSubmitSchema.ts
@@ -71,4 +71,8 @@ export const postV1WorkSessionsIdSubmit404Schema = z.object({
     }).catchall(z.union([z.array(z.string()), z.string()])).optional()
     })
 
+export const postV1WorkSessionsIdSubmitMutationRequestSchema = z.union([z.any(), z.object({
+    "taGrade": z.number().int().min(1).max(5).optional()
+    })])
+
 export const postV1WorkSessionsIdSubmitMutationResponseSchema = z.lazy(() => postV1WorkSessionsIdSubmit200Schema)

--- a/apps/api/src/gen/kubb/zod/postV1WorkSessionsIdSubmitSchema.ts
+++ b/apps/api/src/gen/kubb/zod/postV1WorkSessionsIdSubmitSchema.ts
@@ -71,8 +71,8 @@ export const postV1WorkSessionsIdSubmit404Schema = z.object({
     }).catchall(z.union([z.array(z.string()), z.string()])).optional()
     })
 
-export const postV1WorkSessionsIdSubmitMutationRequestSchema = z.union([z.any(), z.object({
+export const postV1WorkSessionsIdSubmitMutationRequestSchema = z.object({
     "taGrade": z.number().int().min(1).max(5).optional()
-    })])
+    })
 
 export const postV1WorkSessionsIdSubmitMutationResponseSchema = z.lazy(() => postV1WorkSessionsIdSubmit200Schema)

--- a/apps/api/src/http/routes/v1/work-sessions/submit.ts
+++ b/apps/api/src/http/routes/v1/work-sessions/submit.ts
@@ -9,7 +9,10 @@ import {
   ResponseSchema404,
 } from "../../_responses/types";
 import { db } from "@repo/infra/db";
-import { workSession } from "@repo/infra/db/schema";
+import {
+  workSession,
+  teachingAssistantEvaluation,
+} from "@repo/infra/db/schema";
 import {
   assertCanParticipateInChallengeWorkSession,
   loadChallengeWorkAccessContext,
@@ -18,6 +21,12 @@ import {
 const WorkSessionParamsSchema = z.object({
   id: z.string().uuid(),
 });
+
+const SubmitWorkSessionBodySchema = z
+  .object({
+    taGrade: z.number().int().min(1).max(5).optional(),
+  })
+  .optional();
 
 const SubmitWorkSessionResponseSchema = ResponseSchema200.extend({
   data: z.object({
@@ -29,6 +38,7 @@ const SubmitWorkSessionResponseSchema = ResponseSchema200.extend({
 export async function submitWorkSessionRoute(app: FastifyTypedInstance) {
   app.post<{
     Params: z.infer<typeof WorkSessionParamsSchema>;
+    Body: z.infer<typeof SubmitWorkSessionBodySchema>;
   }>(
     "/:id/submit",
     {
@@ -36,8 +46,9 @@ export async function submitWorkSessionRoute(app: FastifyTypedInstance) {
         tags: ["work-sessions"],
         summary: "Submit work session",
         description:
-          "Marks the work session as submitted (sets endedAt). Only the session owner can submit.",
+          "Marks the work session as submitted (sets endedAt). Optionally records an anonymous 1–5 rating for the teaching assistant — only the TA id, grade and timestamp are stored. Only the session owner can submit.",
         params: WorkSessionParamsSchema,
+        body: SubmitWorkSessionBodySchema,
         response: {
           200: SubmitWorkSessionResponseSchema,
           400: ResponseSchema400,
@@ -112,6 +123,15 @@ export async function submitWorkSessionRoute(app: FastifyTypedInstance) {
         return reply.status(400).send({
           success: false as const,
           message: "Could not submit work session",
+        });
+      }
+
+      const taGrade = request.body?.taGrade;
+      if (typeof taGrade === "number") {
+        await db.insert(teachingAssistantEvaluation).values({
+          id: crypto.randomUUID(),
+          teachingAssistantId: session.teachingAssistantId,
+          grade: taGrade,
         });
       }
 

--- a/apps/api/src/http/routes/v1/work-sessions/submit.ts
+++ b/apps/api/src/http/routes/v1/work-sessions/submit.ts
@@ -22,11 +22,9 @@ const WorkSessionParamsSchema = z.object({
   id: z.string().uuid(),
 });
 
-const SubmitWorkSessionBodySchema = z
-  .object({
-    taGrade: z.number().int().min(1).max(5).optional(),
-  })
-  .optional();
+const SubmitWorkSessionBodySchema = z.object({
+  taGrade: z.number().int().min(1).max(5).optional(),
+});
 
 const SubmitWorkSessionResponseSchema = ResponseSchema200.extend({
   data: z.object({
@@ -128,11 +126,21 @@ export async function submitWorkSessionRoute(app: FastifyTypedInstance) {
 
       const taGrade = request.body?.taGrade;
       if (typeof taGrade === "number") {
-        await db.insert(teachingAssistantEvaluation).values({
-          id: crypto.randomUUID(),
-          teachingAssistantId: session.teachingAssistantId,
-          grade: taGrade,
-        });
+        // Best-effort: a failed evaluation insert must not 500 a successful
+        // submission. The rating is anonymous and sparse; losing one is
+        // acceptable, blocking the student is not.
+        try {
+          await db.insert(teachingAssistantEvaluation).values({
+            id: crypto.randomUUID(),
+            teachingAssistantId: session.teachingAssistantId,
+            grade: taGrade,
+          });
+        } catch (err) {
+          request.log.error(
+            { err, teachingAssistantId: session.teachingAssistantId },
+            "Failed to persist teaching assistant evaluation"
+          );
+        }
       }
 
       return reply.status(200).send({

--- a/apps/web/src/app/problem/[id]/_components/Header.tsx
+++ b/apps/web/src/app/problem/[id]/_components/Header.tsx
@@ -128,10 +128,10 @@ function Header() {
                     Submeter resolução?
                   </AlertDialogTitle>
                   <AlertDialogDescription className="text-zinc-400">
-                    Antes de submeter, avalia o Assistente de Ensino (AT) que
-                    te acompanhou nesta sessão, de 1 a 5 estrelas. A tua
+                    Antes de submeter, avalie o Assistente de Ensino (AT) que
+                    lhe acompanhou nesta sessão, de 1 a 5 estrelas. A sua
                     identidade <strong className="text-zinc-200">não</strong>{" "}
-                    será associada à avaliação — apenas o AT, a nota e a data
+                    será associada à avaliação. Apenas o AT, a nota e a data
                     são guardados.
                   </AlertDialogDescription>
                 </AlertDialogHeader>

--- a/apps/web/src/app/problem/[id]/_components/Header.tsx
+++ b/apps/web/src/app/problem/[id]/_components/Header.tsx
@@ -20,6 +20,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { useState } from "react";
+import { Star } from "lucide-react";
 
 function Header() {
   const isTeacherPlus = useHasMinimumRole("teacher");
@@ -34,14 +35,20 @@ function Header() {
   const [reopening, setReopening] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [submitDialogOpen, setSubmitDialogOpen] = useState(false);
+  const [taGrade, setTaGrade] = useState<number>(0);
+  const [taGradeHover, setTaGradeHover] = useState<number>(0);
 
   const hasSession = !!workSession?.id;
 
   const handleSubmit = async () => {
-    if (!hasSession || isSessionEnded) return;
+    if (!hasSession || isSessionEnded || taGrade < 1) return;
     setSubmitting(true);
     try {
-      await submitWorkSession();
+      await submitWorkSession({ taGrade });
+      setSubmitDialogOpen(false);
+      setTaGrade(0);
+      setTaGradeHover(0);
     } finally {
       setSubmitting(false);
     }
@@ -94,16 +101,95 @@ function Header() {
 
           {/* Work session actions */}
           {hasSession && !isSessionEnded && (
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              disabled={submitting}
-              onClick={handleSubmit}
-              className="text-xs bg-zinc-800 hover:bg-zinc-700 text-zinc-200"
+            <AlertDialog
+              open={submitDialogOpen}
+              onOpenChange={(open) => {
+                setSubmitDialogOpen(open);
+                if (!open) {
+                  setTaGrade(0);
+                  setTaGradeHover(0);
+                }
+              }}
             >
-              {submitting ? "A submeter…" : "Submeter"}
-            </Button>
+              <AlertDialogTrigger asChild>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  disabled={submitting}
+                  className="text-xs bg-zinc-800 hover:bg-zinc-700 text-zinc-200"
+                >
+                  {submitting ? "A submeter…" : "Submeter"}
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+                <AlertDialogHeader>
+                  <AlertDialogTitle className="text-zinc-100">
+                    Submeter resolução?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription className="text-zinc-400">
+                    Antes de submeter, avalia o Assistente de Ensino (AT) que
+                    te acompanhou nesta sessão, de 1 a 5 estrelas. A tua
+                    identidade <strong className="text-zinc-200">não</strong>{" "}
+                    será associada à avaliação — apenas o AT, a nota e a data
+                    são guardados.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <div className="py-3">
+                  <div
+                    className="flex items-center gap-1"
+                    role="radiogroup"
+                    aria-label="Avaliação do AT (1 a 5 estrelas)"
+                    onMouseLeave={() => setTaGradeHover(0)}
+                  >
+                    {[1, 2, 3, 4, 5].map((n) => {
+                      const active = (taGradeHover || taGrade) >= n;
+                      return (
+                        <button
+                          key={n}
+                          type="button"
+                          role="radio"
+                          aria-checked={taGrade === n}
+                          aria-label={`${n} estrela${n > 1 ? "s" : ""}`}
+                          onClick={() => setTaGrade(n)}
+                          onMouseEnter={() => setTaGradeHover(n)}
+                          className="p-1 rounded hover:bg-zinc-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+                        >
+                          <Star
+                            className={
+                              active
+                                ? "h-7 w-7 text-amber-400 fill-amber-400"
+                                : "h-7 w-7 text-zinc-600"
+                            }
+                          />
+                        </button>
+                      );
+                    })}
+                    <span className="ml-3 text-sm text-zinc-400 min-w-[3ch]">
+                      {taGrade > 0 ? `${taGrade}/5` : "—"}
+                    </span>
+                  </div>
+                </div>
+                <AlertDialogFooter>
+                  <AlertDialogCancel
+                    disabled={submitting}
+                    className="bg-zinc-800 border-zinc-700 text-zinc-200"
+                  >
+                    Cancelar
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    disabled={submitting || taGrade < 1}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      void handleSubmit();
+                    }}
+                    className="bg-emerald-600 hover:bg-emerald-500 text-white"
+                  >
+                    {submitting ? "A submeter…" : "Confirmar submissão"}
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           )}
 
           {hasSession && isSessionEnded && (

--- a/apps/web/src/contexts/ProblemContext.tsx
+++ b/apps/web/src/contexts/ProblemContext.tsx
@@ -549,7 +549,7 @@ export function ProblemProvider({
         data:
           typeof options?.taGrade === "number"
             ? { taGrade: options.taGrade }
-            : undefined,
+            : {},
       });
     },
     [workSession, saveSolution, submitMutation]

--- a/apps/web/src/contexts/ProblemContext.tsx
+++ b/apps/web/src/contexts/ProblemContext.tsx
@@ -91,7 +91,7 @@ type ProblemContextValue = {
     stdin?: string;
     stdout?: string;
   }) => Promise<{ modelResponse: string }>;
-  submitWorkSession: () => Promise<void>;
+  submitWorkSession: (options?: { taGrade?: number }) => Promise<void>;
   reopenWorkSession: () => Promise<void>;
   resetWorkSession: () => Promise<void>;
 };
@@ -534,16 +534,26 @@ export function ProblemProvider({
     [challengeId, ensureWorkSession, chatMutation, saveSolution]
   );
 
-  const submitWorkSession = useCallback(async () => {
-    if (!workSession?.id || workSession.endedAt) return;
-    const { getCode, getInput, output, error } = useCodeEditorStore.getState();
-    await saveSolution({
-      code: getCode(),
-      stdin: getInput(),
-      stdout: error ?? output ?? undefined,
-    });
-    await submitMutation.mutateAsync({ id: workSession.id });
-  }, [workSession, saveSolution, submitMutation]);
+  const submitWorkSession = useCallback(
+    async (options?: { taGrade?: number }) => {
+      if (!workSession?.id || workSession.endedAt) return;
+      const { getCode, getInput, output, error } =
+        useCodeEditorStore.getState();
+      await saveSolution({
+        code: getCode(),
+        stdin: getInput(),
+        stdout: error ?? output ?? undefined,
+      });
+      await submitMutation.mutateAsync({
+        id: workSession.id,
+        data:
+          typeof options?.taGrade === "number"
+            ? { taGrade: options.taGrade }
+            : undefined,
+      });
+    },
+    [workSession, saveSolution, submitMutation]
+  );
 
   const reopenWorkSession = useCallback(async () => {
     if (!workSession?.id || !workSession.endedAt) return;

--- a/apps/web/src/kubb/hooks/work-sessionsHooks/usePostV1WorkSessionsIdSubmit.ts
+++ b/apps/web/src/kubb/hooks/work-sessionsHooks/usePostV1WorkSessionsIdSubmit.ts
@@ -4,9 +4,9 @@
 */
 
 import fetch from "@/lib/apiClient";
+import type { PostV1WorkSessionsIdSubmitMutationRequest, PostV1WorkSessionsIdSubmitMutationResponse, PostV1WorkSessionsIdSubmitPathParams, PostV1WorkSessionsIdSubmit400, PostV1WorkSessionsIdSubmit401, PostV1WorkSessionsIdSubmit403, PostV1WorkSessionsIdSubmit404 } from "../../../../../../packages/types/kubb/PostV1WorkSessionsIdSubmit.ts";
 import type { RequestConfig, ResponseErrorConfig } from "@/lib/apiClient";
 import type { UseMutationOptions, QueryClient } from "@tanstack/react-query";
-import type { PostV1WorkSessionsIdSubmitMutationResponse, PostV1WorkSessionsIdSubmitPathParams, PostV1WorkSessionsIdSubmit400, PostV1WorkSessionsIdSubmit401, PostV1WorkSessionsIdSubmit403, PostV1WorkSessionsIdSubmit404 } from "../../../../../../packages/types/kubb/PostV1WorkSessionsIdSubmit.ts";
 import { useMutation } from "@tanstack/react-query";
 
 export const postV1WorkSessionsIdSubmitMutationKey = () => [{ url: '/v1/work-sessions/:id/submit' }] as const
@@ -14,35 +14,37 @@ export const postV1WorkSessionsIdSubmitMutationKey = () => [{ url: '/v1/work-ses
 export type PostV1WorkSessionsIdSubmitMutationKey = ReturnType<typeof postV1WorkSessionsIdSubmitMutationKey>
 
 /**
- * @description Marks the work session as submitted (sets endedAt). Only the session owner can submit.
+ * @description Marks the work session as submitted (sets endedAt). Optionally records an anonymous 1–5 rating for the teaching assistant — only the TA id, grade and timestamp are stored. Only the session owner can submit.
  * @summary Submit work session
  * {@link /v1/work-sessions/:id/submit}
  */
-export async function postV1WorkSessionsIdSubmit(id: PostV1WorkSessionsIdSubmitPathParams["id"], config: Partial<RequestConfig> & { client?: typeof fetch } = {}) {
+export async function postV1WorkSessionsIdSubmit(id: PostV1WorkSessionsIdSubmitPathParams["id"], data?: PostV1WorkSessionsIdSubmitMutationRequest, config: Partial<RequestConfig<PostV1WorkSessionsIdSubmitMutationRequest>> & { client?: typeof fetch } = {}) {
   const { client: request = fetch, ...requestConfig } = config  
   
-  const res = await request<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, unknown>({ method : "POST", url : `/v1/work-sessions/${id}/submit`, ... requestConfig })  
+  const requestData = data  
+  
+  const res = await request<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, PostV1WorkSessionsIdSubmitMutationRequest>({ method : "POST", url : `/v1/work-sessions/${id}/submit`, data : requestData, ... requestConfig })  
   return res.data
 }
 
 /**
- * @description Marks the work session as submitted (sets endedAt). Only the session owner can submit.
+ * @description Marks the work session as submitted (sets endedAt). Optionally records an anonymous 1–5 rating for the teaching assistant — only the TA id, grade and timestamp are stored. Only the session owner can submit.
  * @summary Submit work session
  * {@link /v1/work-sessions/:id/submit}
  */
 export function usePostV1WorkSessionsIdSubmit<TContext>(options: 
 {
-  mutation?: UseMutationOptions<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, {id: PostV1WorkSessionsIdSubmitPathParams["id"]}, TContext> & { client?: QueryClient },
-  client?: Partial<RequestConfig> & { client?: typeof fetch },
+  mutation?: UseMutationOptions<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, {id: PostV1WorkSessionsIdSubmitPathParams["id"], data?: PostV1WorkSessionsIdSubmitMutationRequest}, TContext> & { client?: QueryClient },
+  client?: Partial<RequestConfig<PostV1WorkSessionsIdSubmitMutationRequest>> & { client?: typeof fetch },
 }
  = {}) {
   const { mutation = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...mutationOptions } = mutation;
   const mutationKey = mutationOptions.mutationKey ?? postV1WorkSessionsIdSubmitMutationKey()
 
-  return useMutation<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, {id: PostV1WorkSessionsIdSubmitPathParams["id"]}, TContext>({
-    mutationFn: async({ id }) => {
-      return postV1WorkSessionsIdSubmit(id, config)
+  return useMutation<PostV1WorkSessionsIdSubmitMutationResponse, ResponseErrorConfig<PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404>, {id: PostV1WorkSessionsIdSubmitPathParams["id"], data?: PostV1WorkSessionsIdSubmitMutationRequest}, TContext>({
+    mutationFn: async({ id, data }) => {
+      return postV1WorkSessionsIdSubmit(id, data, config)
     },
     mutationKey,
     ...mutationOptions

--- a/packages/infra/drizzle/0004_curly_roulette.sql
+++ b/packages/infra/drizzle/0004_curly_roulette.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "teaching_assistant_evaluation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"teaching_assistant_id" text NOT NULL,
+	"grade" integer NOT NULL,
+	"week" timestamp DEFAULT date_trunc('week', now()) NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "teaching_assistant_evaluation" ADD CONSTRAINT "teaching_assistant_evaluation_teaching_assistant_id_teaching_assistant_id_fk" FOREIGN KEY ("teaching_assistant_id") REFERENCES "public"."teaching_assistant"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "teaching_assistant_evaluation_ta_idx" ON "teaching_assistant_evaluation" USING btree ("teaching_assistant_id");

--- a/packages/infra/drizzle/meta/0004_snapshot.json
+++ b/packages/infra/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2115 @@
+{
+  "id": "1334616a-0adf-452c-bc1c-1e303268f102",
+  "prevId": "e4d535ac-80bf-42ed-aa9d-c25a89a8882e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge": {
+      "name": "challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "classroom_id": {
+          "name": "classroom_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_materials": {
+          "name": "support_materials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "possible_solutions": {
+          "name": "possible_solutions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_classroom_id_classroom_id_fk": {
+          "name": "challenge_classroom_id_classroom_id_fk",
+          "tableFrom": "challenge",
+          "tableTo": "classroom",
+          "columnsFrom": [
+            "classroom_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "challenge_created_by_user_id_user_id_fk": {
+          "name": "challenge_created_by_user_id_user_id_fk",
+          "tableFrom": "challenge",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_knowledge_base": {
+      "name": "challenge_knowledge_base",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_knowledge_base_challenge_id_challenge_id_fk": {
+          "name": "challenge_knowledge_base_challenge_id_challenge_id_fk",
+          "tableFrom": "challenge_knowledge_base",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenge_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "challenge_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "challenge_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "challenge_knowledge_base_challenge_id_knowledge_base_id_pk": {
+          "name": "challenge_knowledge_base_challenge_id_knowledge_base_id_pk",
+          "columns": [
+            "challenge_id",
+            "knowledge_base_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_solution": {
+      "name": "challenge_solution",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_history": {
+          "name": "chat_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout": {
+          "name": "stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenge_solution_user_challenge_idx": {
+          "name": "challenge_solution_user_challenge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenge_solution_user_id_user_id_fk": {
+          "name": "challenge_solution_user_id_user_id_fk",
+          "tableFrom": "challenge_solution",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "challenge_solution_challenge_id_challenge_id_fk": {
+          "name": "challenge_solution_challenge_id_challenge_id_fk",
+          "tableFrom": "challenge_solution",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.challenge_teaching_assistant": {
+      "name": "challenge_teaching_assistant",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teaching_assistant_id": {
+          "name": "teaching_assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_teaching_assistant_challenge_id_challenge_id_fk": {
+          "name": "challenge_teaching_assistant_challenge_id_challenge_id_fk",
+          "tableFrom": "challenge_teaching_assistant",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "challenge_teaching_assistant_teaching_assistant_id_teaching_assistant_id_fk": {
+          "name": "challenge_teaching_assistant_teaching_assistant_id_teaching_assistant_id_fk",
+          "tableFrom": "challenge_teaching_assistant",
+          "tableTo": "teaching_assistant",
+          "columnsFrom": [
+            "teaching_assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "challenge_teaching_assistant_challenge_id_teaching_assistant_id_pk": {
+          "name": "challenge_teaching_assistant_challenge_id_teaching_assistant_id_pk",
+          "columns": [
+            "challenge_id",
+            "teaching_assistant_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.classroom": {
+      "name": "classroom",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_user_id": {
+          "name": "teacher_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "classroom_organization_id_organization_id_fk": {
+          "name": "classroom_organization_id_organization_id_fk",
+          "tableFrom": "classroom",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "classroom_teacher_user_id_user_id_fk": {
+          "name": "classroom_teacher_user_id_user_id_fk",
+          "tableFrom": "classroom",
+          "tableTo": "user",
+          "columnsFrom": [
+            "teacher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_replay": {
+      "name": "conversation_replay",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "original_work_session_id": {
+          "name": "original_work_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replay_teaching_assistant_id": {
+          "name": "replay_teaching_assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversation_replay_session_ta_idx": {
+          "name": "conversation_replay_session_ta_idx",
+          "columns": [
+            {
+              "expression": "original_work_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replay_teaching_assistant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_replay_original_work_session_id_work_session_id_fk": {
+          "name": "conversation_replay_original_work_session_id_work_session_id_fk",
+          "tableFrom": "conversation_replay",
+          "tableTo": "work_session",
+          "columnsFrom": [
+            "original_work_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_replay_replay_teaching_assistant_id_teaching_assistant_id_fk": {
+          "name": "conversation_replay_replay_teaching_assistant_id_teaching_assistant_id_fk",
+          "tableFrom": "conversation_replay",
+          "tableTo": "teaching_assistant",
+          "columnsFrom": [
+            "replay_teaching_assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base": {
+      "name": "knowledge_base",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classroom_id": {
+          "name": "classroom_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_classroom_id_classroom_id_fk": {
+          "name": "knowledge_base_classroom_id_classroom_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "classroom",
+          "columnsFrom": [
+            "classroom_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_organization_id_organization_id_fk": {
+          "name": "knowledge_base_organization_id_organization_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_created_by_user_id_user_id_fk": {
+          "name": "knowledge_base_created_by_user_id_user_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base_chunk": {
+      "name": "knowledge_base_chunk",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kb_embedding_idx": {
+          "name": "kb_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "knowledge_base_chunk_document_id_knowledge_base_document_id_fk": {
+          "name": "knowledge_base_chunk_document_id_knowledge_base_document_id_fk",
+          "tableFrom": "knowledge_base_chunk",
+          "tableTo": "knowledge_base_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_chunk_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_base_chunk_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_base_chunk",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_base_document": {
+      "name": "knowledge_base_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stage": {
+          "name": "error_stage",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_document_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_base_document_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_base_document",
+          "tableTo": "knowledge_base",
+          "columnsFrom": [
+            "knowledge_base_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model": {
+      "name": "model",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_parameters": {
+          "name": "model_parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "model_name_version_idx": {
+          "name": "model_name_version_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replay_interaction": {
+      "name": "replay_interaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "replay_id": {
+          "name": "replay_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_interaction_id": {
+          "name": "original_interaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_response": {
+          "name": "model_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "replay_interaction_replay_id_conversation_replay_id_fk": {
+          "name": "replay_interaction_replay_id_conversation_replay_id_fk",
+          "tableFrom": "replay_interaction",
+          "tableTo": "conversation_replay",
+          "columnsFrom": [
+            "replay_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "replay_interaction_original_interaction_id_user_interaction_on_challenge_id_fk": {
+          "name": "replay_interaction_original_interaction_id_user_interaction_on_challenge_id_fk",
+          "tableFrom": "replay_interaction",
+          "tableTo": "user_interaction_on_challenge",
+          "columnsFrom": [
+            "original_interaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teaching_assistant": {
+      "name": "teaching_assistant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_organization_id": {
+          "name": "created_by_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teaching_assistant_alias_version_idx": {
+          "name": "teaching_assistant_alias_version_idx",
+          "columns": [
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teaching_assistant_model_id_model_id_fk": {
+          "name": "teaching_assistant_model_id_model_id_fk",
+          "tableFrom": "teaching_assistant",
+          "tableTo": "model",
+          "columnsFrom": [
+            "model_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teaching_assistant_created_by_organization_id_organization_id_fk": {
+          "name": "teaching_assistant_created_by_organization_id_organization_id_fk",
+          "tableFrom": "teaching_assistant",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "created_by_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teaching_assistant_evaluation": {
+      "name": "teaching_assistant_evaluation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teaching_assistant_id": {
+          "name": "teaching_assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('week', now())"
+        }
+      },
+      "indexes": {
+        "teaching_assistant_evaluation_ta_idx": {
+          "name": "teaching_assistant_evaluation_ta_idx",
+          "columns": [
+            {
+              "expression": "teaching_assistant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teaching_assistant_evaluation_teaching_assistant_id_teaching_assistant_id_fk": {
+          "name": "teaching_assistant_evaluation_teaching_assistant_id_teaching_assistant_id_fk",
+          "tableFrom": "teaching_assistant_evaluation",
+          "tableTo": "teaching_assistant",
+          "columnsFrom": [
+            "teaching_assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_classroom": {
+      "name": "user_classroom",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classroom_id": {
+          "name": "classroom_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_classroom_user_id_user_id_fk": {
+          "name": "user_classroom_user_id_user_id_fk",
+          "tableFrom": "user_classroom",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_classroom_classroom_id_classroom_id_fk": {
+          "name": "user_classroom_classroom_id_classroom_id_fk",
+          "tableFrom": "user_classroom",
+          "tableTo": "classroom",
+          "columnsFrom": [
+            "classroom_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_classroom_user_id_classroom_id_pk": {
+          "name": "user_classroom_user_id_classroom_id_pk",
+          "columns": [
+            "user_id",
+            "classroom_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interaction_on_challenge": {
+      "name": "user_interaction_on_challenge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "work_session_id": {
+          "name": "work_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interaction_type": {
+          "name": "interaction_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "user_prompt": {
+          "name": "user_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "model_response": {
+          "name": "model_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdin": {
+          "name": "stdin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stdout": {
+          "name": "stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_interaction_on_challenge_work_session_id_work_session_id_fk": {
+          "name": "user_interaction_on_challenge_work_session_id_work_session_id_fk",
+          "tableFrom": "user_interaction_on_challenge",
+          "tableTo": "work_session",
+          "columnsFrom": [
+            "work_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_interaction_on_challenge_challenge_id_challenge_id_fk": {
+          "name": "user_interaction_on_challenge_challenge_id_challenge_id_fk",
+          "tableFrom": "user_interaction_on_challenge",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_session": {
+      "name": "work_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classroom_id": {
+          "name": "classroom_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teaching_assistant_id": {
+          "name": "teaching_assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "work_session_user_challenge_idx": {
+          "name": "work_session_user_challenge_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "work_session_user_id_user_id_fk": {
+          "name": "work_session_user_id_user_id_fk",
+          "tableFrom": "work_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_session_challenge_id_challenge_id_fk": {
+          "name": "work_session_challenge_id_challenge_id_fk",
+          "tableFrom": "work_session",
+          "tableTo": "challenge",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_session_classroom_id_classroom_id_fk": {
+          "name": "work_session_classroom_id_classroom_id_fk",
+          "tableFrom": "work_session",
+          "tableTo": "classroom",
+          "columnsFrom": [
+            "classroom_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "work_session_teaching_assistant_id_teaching_assistant_id_fk": {
+          "name": "work_session_teaching_assistant_id_teaching_assistant_id_fk",
+          "tableFrom": "work_session",
+          "tableTo": "teaching_assistant",
+          "columnsFrom": [
+            "teaching_assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/infra/drizzle/meta/_journal.json
+++ b/packages/infra/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778114314918,
       "tag": "0003_work_session_user_challenge_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1778803669749,
+      "tag": "0004_curly_roulette",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/infra/src/db/schema/app.ts
+++ b/packages/infra/src/db/schema/app.ts
@@ -370,6 +370,28 @@ export const replayInteraction = pgTable("replay_interaction", {
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 
+// ==================== TEACHING ASSISTANT EVALUATIONS ====================
+//
+// Anonymous student rating of the TA captured at submit time.
+// Privacy: only teachingAssistantId + grade + timestamp are persisted —
+// no userId / workSessionId / challengeId, so a rating cannot be traced
+// back to a specific student.
+
+export const teachingAssistantEvaluation = pgTable(
+  "teaching_assistant_evaluation",
+  {
+    id: text("id").primaryKey(),
+    teachingAssistantId: text("teaching_assistant_id")
+      .notNull()
+      .references(() => teachingAssistant.id, { onDelete: "cascade" }),
+    grade: integer("grade").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("teaching_assistant_evaluation_ta_idx").on(table.teachingAssistantId),
+  ]
+);
+
 // ==================== EXPORT TYPES ====================
 
 export type Classroom = typeof classroom.$inferSelect;
@@ -397,3 +419,7 @@ export type NewKnowledgeBaseDocument = typeof knowledgeBaseDocument.$inferInsert
 export type ChallengeKnowledgeBase = typeof challengeKnowledgeBase.$inferSelect;
 export type ConversationReplay = typeof conversationReplay.$inferSelect;
 export type ReplayInteraction = typeof replayInteraction.$inferSelect;
+export type TeachingAssistantEvaluation =
+  typeof teachingAssistantEvaluation.$inferSelect;
+export type NewTeachingAssistantEvaluation =
+  typeof teachingAssistantEvaluation.$inferInsert;

--- a/packages/infra/src/db/schema/app.ts
+++ b/packages/infra/src/db/schema/app.ts
@@ -11,6 +11,7 @@ import {
   index,
   customType,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user, organization } from "./auth";
 
 // ==================== CUSTOM TYPES ====================
@@ -373,9 +374,10 @@ export const replayInteraction = pgTable("replay_interaction", {
 // ==================== TEACHING ASSISTANT EVALUATIONS ====================
 //
 // Anonymous student rating of the TA captured at submit time.
-// Privacy: only teachingAssistantId + grade + timestamp are persisted —
-// no userId / workSessionId / challengeId, so a rating cannot be traced
-// back to a specific student.
+// Privacy: only teachingAssistantId + grade + week are persisted; the
+// timestamp is truncated to the start of the ISO week so a rating cannot
+// be correlated with a specific work_session.ended_at to re-identify the
+// student.
 
 export const teachingAssistantEvaluation = pgTable(
   "teaching_assistant_evaluation",
@@ -385,7 +387,9 @@ export const teachingAssistantEvaluation = pgTable(
       .notNull()
       .references(() => teachingAssistant.id, { onDelete: "cascade" }),
     grade: integer("grade").notNull(),
-    createdAt: timestamp("created_at").notNull().defaultNow(),
+    week: timestamp("week")
+      .notNull()
+      .default(sql`date_trunc('week', now())`),
   },
   (table) => [
     index("teaching_assistant_evaluation_ta_idx").on(table.teachingAssistantId),

--- a/packages/types/kubb/PostV1WorkSessionsIdSubmit.ts
+++ b/packages/types/kubb/PostV1WorkSessionsIdSubmit.ts
@@ -169,14 +169,14 @@ export type PostV1WorkSessionsIdSubmit404 = {
     };
 };
 
-export type PostV1WorkSessionsIdSubmitMutationRequest = (any | {
+export type PostV1WorkSessionsIdSubmitMutationRequest = {
     /**
      * @minLength 1
      * @maxLength 5
      * @type integer | undefined
     */
     taGrade?: number;
-});
+};
 
 export type PostV1WorkSessionsIdSubmitMutationResponse = PostV1WorkSessionsIdSubmit200;
 

--- a/packages/types/kubb/PostV1WorkSessionsIdSubmit.ts
+++ b/packages/types/kubb/PostV1WorkSessionsIdSubmit.ts
@@ -169,10 +169,20 @@ export type PostV1WorkSessionsIdSubmit404 = {
     };
 };
 
+export type PostV1WorkSessionsIdSubmitMutationRequest = (any | {
+    /**
+     * @minLength 1
+     * @maxLength 5
+     * @type integer | undefined
+    */
+    taGrade?: number;
+});
+
 export type PostV1WorkSessionsIdSubmitMutationResponse = PostV1WorkSessionsIdSubmit200;
 
 export type PostV1WorkSessionsIdSubmitMutation = {
     Response: PostV1WorkSessionsIdSubmit200;
+    Request: PostV1WorkSessionsIdSubmitMutationRequest;
     PathParams: PostV1WorkSessionsIdSubmitPathParams;
     Errors: PostV1WorkSessionsIdSubmit400 | PostV1WorkSessionsIdSubmit401 | PostV1WorkSessionsIdSubmit403 | PostV1WorkSessionsIdSubmit404;
 };


### PR DESCRIPTION
Closes #86

## Summary
- Adiciona tabela `teaching_assistant_evaluation` (apenas `teachingAssistantId`, `grade`, `createdAt`) — sem `userId`/`workSessionId`/`challengeId` para preservar o anonimato do aluno.
- `POST /v1/work-sessions/:id/submit` passa a aceitar opcionalmente `taGrade` (1–5) e regista a avaliação usando o `teachingAssistantId` da própria sessão.
- O botão **Submeter** passa por um diálogo de confirmação com selector de 1 a 5 estrelas e nota explícita ao aluno: a sua identidade não é associada à avaliação.

## Test plan
- [ ] Submeter uma sessão sem escolher estrelas → confirmar não permite avançar.
- [ ] Submeter com 3 estrelas → linha inserida em `teaching_assistant_evaluation` apenas com `teachingAssistantId`, `grade=3` e `createdAt`.
- [ ] Re-tentar submeter sessão já terminada → 400 sem inserir nova linha.
- [ ] Cancelar o diálogo → nenhuma chamada à API, estado das estrelas reset no próximo open.