### PR TITLE
PR-screenshot skill

### DIFF
--- a/.claude/skills/pr-screenshots/SKILL.md
+++ b/.claude/skills/pr-screenshots/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: pr-screenshots
+description: Run the Playwright e2e suite, capture screenshots at asserted milestones, and embed them at the top of a PR description as visual proof of the change. Use when opening or updating a PR, or whenever the user asks for screenshot evidence on a PR.
+---
+
+# PR Screenshots
+
+Turns a passing e2e run into visual proof at the top of the PR description: a
+collapsible `<details>` block (with an `<h2>` summary) holding screenshots
+captured during the test run, hosted on a per-PR secret gist.
+
+## When to use
+
+- Preparing a PR that changes UI, or asked to add "proof of the changes".
+- Re-generating evidence after pushing UI fixes (the embed is idempotent —
+  re-running replaces the old block and gist).
+
+## Prerequisites
+
+- Dev DB seeded: `cd packages/infra && npm run db:seed:dev` (creates the
+  `professor@taco-demo.local` / `aluno@taco-demo.local` accounts).
+- `gh` authenticated, `git`, `python3` available.
+- A PR already exists for the current branch (`gh pr view` resolves it).
+- **Permission**: pushing to a gist may be blocked by the auto-mode safety
+  classifier the first time. The user must approve it / add a Bash permission
+  rule for `git push` to `gist.github.com`. Flag this if it gets denied —
+  do not try to bypass it.
+
+## How screenshots are captured
+
+Specs capture with the shared helper `e2e/helpers/screenshots.ts`:
+
+```ts
+import { makeShooter } from "./helpers/screenshots";
+
+test("...", async ({ page }, testInfo) => {
+  const shot = makeShooter(page, testInfo); // 3rd arg `true` => fullPage
+  // ... drive the UI ...
+  await expect(successAlert).toBeVisible();
+  await shot("grade-saved");                // capture AFTER the assertion
+});
+```
+
+Each `shot(name)` writes
+`test-results/screenshots/<test-slug>/NN-<name>.png` (auto-numbered, grouped
+per test) and attaches it to the HTML report.
+
+**Rules for good evidence:**
+- Capture *after* the `expect(...)` that proves the state — the screenshot is
+  evidence of an asserted state, not whatever happened to render.
+- Name shots descriptively in kebab-case; the embed humanizes the filename
+  into the caption (`03-grade-saved` → "grade saved"), and the test-dir name
+  into the section header. Good names = good captions, for free.
+- `test-results/` is gitignored — these are artifacts, never committed.
+
+## Workflow
+
+1. **Run the suite** — it must pass before posting evidence:
+   ```bash
+   npm run test:e2e
+   ```
+   If it fails, fix the test/code first. Do not post screenshots of a failing
+   run as if it passed.
+
+2. **Embed into the PR** (uploads to a fresh secret gist, then prepends/
+   replaces the block at the top of the description):
+   ```bash
+   .claude/skills/pr-screenshots/scripts/pr-screenshots.sh <pr-number>
+   # optional 2nd arg: owner/repo (defaults to the current repo)
+   ```
+
+3. **Verify rendering** — open the PR URL the script prints and confirm the
+   images actually display. Gist-raw hotlinks usually render, but GitHub's
+   image proxy can occasionally reject them. If any image is broken, the
+   fallback is an assets branch hotlinked via `raw.githubusercontent.com`
+   (most reliable host) — switch to that and tell the user.
+
+## Notes & gotchas
+
+- **Delete-and-rebuild on re-run.** Each run creates a fresh secret gist (the
+  description is `<repo> PR #<n> — e2e screenshot evidence`). If the PR already
+  has a screenshot block, the script reads the old gist ID(s) from it,
+  rebuilds the section against the new gist, and — only *after* the PR body is
+  updated — deletes the previous gist so no stale images are left behind. If a
+  delete fails it warns with the manual `gh gist delete <id>` command.
+- **Secret ≠ private.** Anyone with the gist URL can view the images. Don't use
+  this on a repo whose UI is sensitive without confirming with the user.
+- **Idempotent embed.** The block is wrapped in
+  `<!-- e2e-screenshots:start -->` / `<!-- e2e-screenshots:end -->` markers;
+  the script replaces between them on re-run, so the description never stacks
+  duplicate blocks.
+- **Binary integrity.** PNGs are pushed via `git` (cloned gist), not
+  `gh gist create` directly — the latter mangles binary as UTF-8 text.

--- a/.claude/skills/pr-screenshots/scripts/pr-screenshots.sh
+++ b/.claude/skills/pr-screenshots/scripts/pr-screenshots.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Upload the e2e screenshots produced by the Playwright suite to a secret
+# gist and embed them at the TOP of a PR description, inside a collapsible
+# <details> block whose <summary> is an <h2>.
+#
+# Re-runnable: the block is wrapped in HTML markers. A second run REPLACES the
+# previous block AND deletes the previous gist (no orphaned gists / images) —
+# the section is rebuilt from scratch with a fresh gist every time.
+#
+# Usage:
+#   pr-screenshots.sh <pr-number> [owner/repo]
+#
+# Reads PNGs from test-results/screenshots/** (the layout produced by
+# e2e/helpers/screenshots.ts -> makeShooter). Run `npm run test:e2e` first.
+#
+# Requires: gh (authenticated), git, python3.
+#
+# NOTE: pushing to a gist may be blocked by Claude Code's auto-mode safety
+# classifier the first time — the user must approve / add a Bash permission
+# rule for `git push` to gist.github.com. Secret gists are NOT truly private
+# (anyone with the URL can view). Confirm with the user before running on a
+# repo with sensitive UI.
+set -euo pipefail
+
+PR="${1:?usage: pr-screenshots.sh <pr-number> [owner/repo]}"
+REPO="${2:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+
+SHOT_DIR="test-results/screenshots"
+[[ -d "$SHOT_DIR" ]] || { echo "no screenshots at $SHOT_DIR — run 'npm run test:e2e' first" >&2; exit 1; }
+
+# Collect PNGs in stable order (bash 3.2 compatible — no mapfile).
+PNGS=()
+while IFS= read -r f; do PNGS+=("$f"); done < <(find "$SHOT_DIR" -type f -name '*.png' | sort)
+[[ ${#PNGS[@]} -gt 0 ]] || { echo "no PNGs under $SHOT_DIR" >&2; exit 1; }
+echo "Found ${#PNGS[@]} screenshot(s)."
+
+GH_USER="$(gh api user --jq .login)"
+
+# --- 0. snapshot the current PR body; find any gist already embedded ---
+ORIG="$(mktemp)"
+gh pr view "$PR" -R "$REPO" --json body --jq .body > "$ORIG"
+# Old gist IDs referenced by a previous run (gist raw URLs). Unique.
+OLD_GIDS=()
+while IFS= read -r gid; do [[ -n "$gid" ]] && OLD_GIDS+=("$gid"); done < <(
+  grep -oE 'gist\.githubusercontent\.com/[^/]+/[0-9a-f]+/raw' "$ORIG" \
+    | sed -E 's#.*/([0-9a-f]+)/raw#\1#' | sort -u
+)
+
+# --- 1. create a secret gist with a throwaway placeholder file ---
+DESC="${REPO} PR #${PR} — e2e screenshot evidence"
+PLACEHOLDER="$(mktemp -t prshots.XXXX).md"
+printf 'PR #%s e2e screenshot evidence\n' "$PR" > "$PLACEHOLDER"
+GIST_URL="$(gh gist create --desc "$DESC" "$PLACEHOLDER")"
+GID="$(basename "$GIST_URL")"
+RAW_BASE="https://gist.githubusercontent.com/${GH_USER}/${GID}/raw"
+echo "Gist: $GIST_URL"
+
+# --- 2. clone the gist (auth required for secret gists), add PNGs, push ---
+TOK="$(gh auth token)"
+WORK="$(mktemp -d)"
+git clone -q "https://${GH_USER}:${TOK}@gist.github.com/${GID}.git" "$WORK"
+rm -f "$WORK/$(basename "$PLACEHOLDER")"   # drop the placeholder in the same push
+
+for src in "${PNGS[@]}"; do
+  rel="${src#"$SHOT_DIR"/}"        # e.g. professor-flow/03-grade-saved.png
+  key="${rel//\//__}"             # professor-flow__03-grade-saved.png (gist keys can't have /)
+  cp "$src" "$WORK/$key"
+done
+
+(
+  cd "$WORK"
+  git add -A
+  git -c user.email="$(git config user.email 2>/dev/null || echo bot@local)" \
+      -c user.name="$(git config user.name 2>/dev/null || echo bot)" \
+      commit -q -m "PR #$PR e2e screenshots"
+  git push -q origin HEAD
+)
+
+# --- 3. build the markdown block, grouped by test directory ---
+BLOCK="$(mktemp)"
+{
+  echo '<!-- e2e-screenshots:start -->'
+  echo '<details>'
+  echo '<summary><h2>📸 E2E Screenshots (proof of changes)</h2></summary>'
+  echo
+  echo 'Captured automatically by the Playwright suite (`npm run test:e2e`).'
+  prev_group=""
+  idx=0
+  for src in "${PNGS[@]}"; do
+    rel="${src#"$SHOT_DIR"/}"
+    group="${rel%%/*}"
+    base="$(basename "$rel" .png)"
+    key="${rel//\//__}"
+    ghuman="$(echo "$group" | tr '-' ' ')"
+    chuman="$(echo "$base" | sed -E 's/^[0-9]+-//; s/-/ /g')"
+    if [[ "$group" != "$prev_group" ]]; then
+      echo
+      echo "### ${ghuman}"
+      prev_group="$group"
+    fi
+    idx=$((idx + 1))
+    echo
+    echo "**${idx}. ${chuman}**"
+    echo
+    echo "![${chuman}](${RAW_BASE}/${key})"
+  done
+  echo
+  echo '</details>'
+  echo '<!-- e2e-screenshots:end -->'
+} > "$BLOCK"
+
+# --- 4. prepend (or replace, if already present) the block in the PR body ---
+NEWBODY="$(mktemp)"
+python3 - "$ORIG" "$BLOCK" "$NEWBODY" <<'PY'
+import sys
+orig  = open(sys.argv[1]).read()
+block = open(sys.argv[2]).read().rstrip() + "\n"
+start, end = "<!-- e2e-screenshots:start -->", "<!-- e2e-screenshots:end -->"
+if start in orig and end in orig:
+    pre  = orig[:orig.index(start)]
+    post = orig[orig.index(end) + len(end):]
+    out  = pre + block.rstrip() + post
+else:
+    out = block + "\n---\n\n" + orig
+open(sys.argv[3], "w").write(out)
+PY
+gh pr edit "$PR" -R "$REPO" --body-file "$NEWBODY"
+echo "Updated PR #$PR with ${#PNGS[@]} screenshot(s)."
+
+# --- 5. only AFTER the PR points at the new gist, delete the old one(s) ---
+for old in "${OLD_GIDS[@]}"; do
+  if [[ "$old" != "$GID" ]]; then
+    if gh gist delete "$old" --yes 2>/dev/null; then
+      echo "Deleted previous gist $old."
+    else
+      echo "WARN: could not delete previous gist $old (delete manually: gh gist delete $old)." >&2
+    fi
+  fi
+done
+
+echo "VERIFY the images render at: $(gh pr view "$PR" -R "$REPO" --json url --jq .url)"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ uploads/
 *.pem
 .claude/history/
 .playwright-cli/
+.understand-anything/
+
+# Playwright test artifacts (screenshots are gisted into PR descriptions, not committed)
+test-results/


### PR DESCRIPTION
## What

Adds the `pr-screenshots` Claude Code skill — turns a passing Playwright e2e run into visual proof at the top of a PR description — and gitignores the `test-results/` artifacts it produces.

## Why

Reviewers shouldn't have to pull a branch and run the UI to see that a change works. This skill captures screenshots at asserted milestones during the e2e suite and embeds them into the PR description as evidence, so the proof lives with the change. Screenshots are hosted out-of-tree (secret gist) rather than committed to the repo.

## Changes

- **`.claude/skills/pr-screenshots/SKILL.md`** — skill definition: when to use, how screenshots are captured (`makeShooter` helper, capture *after* the assertion), and the run → embed → verify workflow.
- **`.claude/skills/pr-screenshots/scripts/pr-screenshots.sh`** — uploads captured PNGs to a fresh secret gist and prepends/replaces an idempotent `<details>` block in the PR body (delete-and-rebuild on re-run, marker-wrapped so it never stacks duplicates).
- **`.gitignore`** — ignore `test-results/`; screenshots are gisted into PR descriptions, not committed.

## Notes

- Requires `gh` authenticated, `git`, and `python3`.
- Pushing to a gist may trip the auto-mode safety classifier the first time and need a one-time approval.
- Secret gists are not private — anyone with the URL can view the images.
