### PR TITLE
fix(pr-screenshots): address review feedback from PR #93

### DIFF
--- a/.claude/skills/pr-screenshots/scripts/pr-screenshots.sh
+++ b/.claude/skills/pr-screenshots/scripts/pr-screenshots.sh
@@ -23,6 +23,17 @@
 # repo with sensitive UI.
 set -euo pipefail
 
+# Clean up temp files and the cloned gist dir on exit. The clone's .git/config
+# embeds the gh auth token in plain text, so this also removes a credential at
+# rest. Guarded with ${VAR:-} since the trap fires even on early abort.
+cleanup() {
+  rm -f "${ORIG:-}" "${PLACEHOLDER:-}" "${BLOCK:-}" "${NEWBODY:-}"
+  if [[ -n "${WORK:-}" && -d "$WORK" ]]; then
+    rm -rf "$WORK"
+  fi
+}
+trap cleanup EXIT
+
 PR="${1:?usage: pr-screenshots.sh <pr-number> [owner/repo]}"
 REPO="${2:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
@@ -43,8 +54,8 @@ gh pr view "$PR" -R "$REPO" --json body --jq .body > "$ORIG"
 # Old gist IDs referenced by a previous run (gist raw URLs). Unique.
 OLD_GIDS=()
 while IFS= read -r gid; do [[ -n "$gid" ]] && OLD_GIDS+=("$gid"); done < <(
-  grep -oE 'gist\.githubusercontent\.com/[^/]+/[0-9a-f]+/raw' "$ORIG" \
-    | sed -E 's#.*/([0-9a-f]+)/raw#\1#' | sort -u
+  grep -oE 'gist\.githubusercontent\.com/[^/]+/[0-9a-f]+/raw' "$ORIG" 2>/dev/null \
+    | sed -E 's#.*/([0-9a-f]+)/raw#\1#' | sort -u || true
 )
 
 # --- 1. create a secret gist with a throwaway placeholder file ---
@@ -114,8 +125,8 @@ BLOCK="$(mktemp)"
 NEWBODY="$(mktemp)"
 python3 - "$ORIG" "$BLOCK" "$NEWBODY" <<'PY'
 import sys
-orig  = open(sys.argv[1]).read()
-block = open(sys.argv[2]).read().rstrip() + "\n"
+orig  = open(sys.argv[1], encoding="utf-8").read()
+block = open(sys.argv[2], encoding="utf-8").read().rstrip() + "\n"
 start, end = "<!-- e2e-screenshots:start -->", "<!-- e2e-screenshots:end -->"
 if start in orig and end in orig:
     pre  = orig[:orig.index(start)]
@@ -123,7 +134,7 @@ if start in orig and end in orig:
     out  = pre + block.rstrip() + post
 else:
     out = block + "\n---\n\n" + orig
-open(sys.argv[3], "w").write(out)
+open(sys.argv[3], "w", encoding="utf-8").write(out)
 PY
 gh pr edit "$PR" -R "$REPO" --body-file "$NEWBODY"
 echo "Updated PR #$PR with ${#PNGS[@]} screenshot(s)."


### PR DESCRIPTION
Follow-up to #93, which was merged before the review comments (from `gemini-code-assist`) were addressed. All three were in `pr-screenshots.sh`.

## Changes

1. **Cleanup trap (security + leak)** — `git clone` of the secret gist embeds the `gh` auth token in plain text inside `$WORK/.git/config`. Without cleanup that token-bearing dir, plus the `mktemp` files, lingered in `/tmp`. Added `trap cleanup EXIT` with `${VAR:-}` guards so it's safe even on early abort.
2. **`grep` pipefail guard (bug)** — on a clean first run no gists are embedded yet, so `grep` exits 1 and could abort the script under `set -o pipefail`. Appended `2>/dev/null ... || true`.
3. **UTF-8 encoding (portability)** — the inline Python `open()` calls now pass `encoding="utf-8"` so the 📸 emoji block doesn't crash in non-UTF-8 locales.

Verified with `bash -n` and `python3 ast.parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)