### PR TITLE
feat(agents): use gpt-4o-mini (temperature=0) for deterministic reference solutions & auto-review

### DIFF
--- a/apps/api/src/agents/teachers-companion/auto-review.ts
+++ b/apps/api/src/agents/teachers-companion/auto-review.ts
@@ -12,6 +12,7 @@ import {
   AGENT_TIMEOUT_MS,
   AgentTimeoutError,
 } from "../llm-factory";
+import { env } from "@repo/infra/env";
 
 const REVIEW_PROMPT = `\
 You are an AI assistant for a programming teacher. Evaluate a student's \
@@ -154,13 +155,11 @@ export async function runAutoReview(submissionId: string): Promise<void> {
       .filter(Boolean)
       .join("\n");
 
-    // TEMP(no-4o-mini): The only Azure deployment in this resource is
-    // gpt-5.2-chat, which rejects custom `temperature` and `max_tokens`. Fall
-    // back to the default chat model with no overrides until a non-reasoning
-    // deterministic model (e.g. gpt-4o-mini) is deployed. Revert to
-    // `createLlm({ model: env.LLM_DETERMINISTIC_MODEL_NAME, temperature: 0.2,
-    // max_tokens: 2048 })` once that deployment exists.
-    const llm = createLlm();
+    const llm = createLlm({
+      model: env.LLM_DETERMINISTIC_MODEL_NAME,
+      temperature: 0,
+      max_tokens: 2048,
+    });
     const controller = new AbortController();
     const timeout = setTimeout(() => {
       controller.abort(new AgentTimeoutError(AGENT_TIMEOUT_MS));

--- a/apps/api/src/agents/teachers-companion/reference-solution.ts
+++ b/apps/api/src/agents/teachers-companion/reference-solution.ts
@@ -115,7 +115,7 @@ async function runOneKind(
     const llm = createLlm({
       model: env.LLM_DETERMINISTIC_MODEL_NAME,
       temperature: 0,
-      max_tokens: 1024,
+      max_tokens: 4096,
     });
     const prompt = prompts[kind](chal.title, chal.description ?? "");
     const result = await llm.invoke(prompt);

--- a/apps/api/src/agents/teachers-companion/reference-solution.ts
+++ b/apps/api/src/agents/teachers-companion/reference-solution.ts
@@ -5,6 +5,7 @@ import {
   challengeReferenceSolution,
 } from "@repo/infra/db/schema";
 import { createLlm } from "../llm-factory";
+import { env } from "@repo/infra/env";
 import { randomUUID } from "node:crypto";
 
 type Kind = "brute_force" | "refined";
@@ -111,13 +112,11 @@ async function runOneKind(
   }
 
   try {
-    // TEMP(no-4o-mini): The only Azure deployment in this resource is
-    // gpt-5.2-chat, which rejects custom `temperature` and `max_tokens`. Fall
-    // back to the default chat model with no overrides until a non-reasoning
-    // deterministic model (e.g. gpt-4o-mini) is deployed. Revert to
-    // `createLlm({ model: env.LLM_DETERMINISTIC_MODEL_NAME, temperature: 0.2,
-    // max_tokens: 1024 })` once that deployment exists.
-    const llm = createLlm();
+    const llm = createLlm({
+      model: env.LLM_DETERMINISTIC_MODEL_NAME,
+      temperature: 0,
+      max_tokens: 1024,
+    });
     const prompt = prompts[kind](chal.title, chal.description ?? "");
     const result = await llm.invoke(prompt);
     const text =


### PR DESCRIPTION
## Summary

gpt-4o-mini is now deployed on Azure (`https://taco-ide-resource.services.ai.azure.com/openai/v1`), so we can remove the `TEMP(no-4o-mini)` workaround and switch the **reference solution** and **auto-review** agents to deterministic LLM calls.

Setting **temperature = 0** makes both features produce consistent, repeatable responses — which is what we want for grading and reference solutions.

## Changes

- **`reference-solution.ts`** — `createLlm({ model: env.LLM_DETERMINISTIC_MODEL_NAME, temperature: 0, max_tokens: 1024 })`
- **`auto-review.ts`** — `createLlm({ model: env.LLM_DETERMINISTIC_MODEL_NAME, temperature: 0, max_tokens: 2048 })`
- Removed the obsolete `TEMP(no-4o-mini)` comment blocks from both files.

`LLM_DETERMINISTIC_MODEL_NAME` already exists in `packages/infra/src/env.ts` (default `gpt-4o-mini`), so no env changes are required.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — no new warnings (pre-existing `any`/unused warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)