### PR TITLE
feat(deploy): docker infra para VMs + teste local

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Build context = repo root. Per-app .dockerignore files are NOT read for a
+# root-context build, so all exclusions live here.
+
+# Dependencies (reinstalled inside the image via npm ci)
+**/node_modules
+infra/                  # orphan stray node_modules dir, not a workspace
+
+# Build outputs
+**/.next
+**/dist
+**/out
+**/.turbo
+**/*.tsbuildinfo
+
+# VCS / tooling / editor
+.git
+.github
+.gitignore
+.claude
+.cursor
+.vscode
+.idea
+.plans
+.understand-anything
+
+# Local env files (secrets are injected at runtime via compose, never baked)
+.env
+.env.*
+
+# Tests / artifacts / generated docs
+coverage
+test-results
+playwright-report
+playwright/.cache
+.playwright-mcp
+.playwright-cli
+apps/api/src/swagger.yaml
+
+# Runtime data
+**/uploads
+
+# Non-build assets
+**/*.md
+docs/
+demo/
+design-reference/
+e2e/
+.DS_Store
+*.pem
+*.log

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,63 @@
+# ==========================================================================
+# TACO-IDE — Docker env template
+# Copy to `.env` in the repo root:  cp .env.docker.example .env
+#
+# LOCAL (compose.yaml):     only the secrets below are optional; the stack boots
+#                           with built-in defaults. Set LLM_API_KEY for AI features.
+# PRODUCTION (compose.prod.yaml): DOMAIN, DATABASE_URL, BETTER_AUTH_SECRET and
+#                           LLM_API_KEY are REQUIRED (compose fails fast if unset).
+# ==========================================================================
+
+# --- Production public domain (compose.prod.yaml only) ---------------------
+# DNS A/AAAA record must point at the VM. web + API are served from this one
+# origin over HTTPS (Caddy provisions the certificate automatically).
+DOMAIN=taco.example.edu
+# ACME_EMAIL=ops@example.edu        # optional contact for Let's Encrypt
+
+# --- Database --------------------------------------------------------------
+# LOCAL: leave unset — compose.yaml points the app at the bundled `db` container.
+# PRODUCTION: your EXTERNAL Postgres. It must have the pgvector extension
+# available (managed Postgres: allow-list it first — RDS rds.allowed_extensions /
+# Azure azure.extensions). Append ?sslmode=require for managed/SSL databases.
+# DATABASE_URL=postgresql://USER:PASSWORD@db-host:5432/taco?sslmode=require
+
+# --- Better Auth (REQUIRED) ------------------------------------------------
+# Generate: openssl rand -base64 48
+BETTER_AUTH_SECRET=change-me-generate-a-random-secret-at-least-32-chars
+
+# --- LLM (REQUIRED at boot — the API will not start without it) -------------
+# Azure OpenAI by default. LLM_API_BASE/model names have defaults; override as needed.
+LLM_API_KEY=replace-me
+# LLM_API_BASE=https://<your-resource>.openai.azure.com/openai/v1/
+# LLM_MODEL_NAME=gpt-4o-mini
+# LLM_DETERMINISTIC_MODEL_NAME=gpt-4o-mini
+
+# --- Email (Resend) — effectively REQUIRED in production -------------------
+# Without it, prod requires email verification but no mail is sent, so newly
+# registered users can never verify and cannot sign in.
+# RESEND_API_KEY=re_xxxxxxxxxxxxx
+# EMAIL_FROM=noreply@taco-ide.com
+
+# --- Embeddings (optional; needed for Knowledge Base semantic search) ------
+# Keep EMBEDDING_DIMENSIONS=1536 — the DB column is fixed at 1536.
+# EMBEDDING_PROVIDER=azure
+# EMBEDDING_API_URL=https://<resource>.cognitiveservices.azure.com/openai/deployments/text-embedding-3-small/embeddings?api-version=2024-02-01
+# EMBEDDING_API_KEY=
+# EMBEDDING_MODEL=text-embedding-3-small
+# EMBEDDING_DIMENSIONS=1536
+
+# --- Platform admin seed (optional) ----------------------------------------
+# If all three are set, the migrate job creates a verified platform admin.
+# Quote passwords containing #, $ or ; so dotenv doesn't truncate them.
+# PLATFORM_ADMIN_EMAIL=admin@example.edu
+# PLATFORM_ADMIN_PASSWORD="at-least-12-characters"
+# PLATFORM_ADMIN_NAME=Platform Admin
+
+# --- Optional extras -------------------------------------------------------
+# CLOUDFLARE_TURNSTILE_SECRET=
+# OPENROUTER_API_KEY=
+# CODE_EXEC_API_URL=https://emkc.org/api/v2/piston/execute
+# LANGFUSE_ENABLED=true
+# LANGFUSE_PUBLIC_KEY=pk-lf-...
+# LANGFUSE_SECRET_KEY=sk-lf-...
+# LANGFUSE_BASEURL=https://us.cloud.langfuse.com

--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ taco-ide/
 - **Resend** - Email delivery service
 - **Docker** - PostgreSQL container
 
+## Deploy (Docker)
+
+Full stack in containers (backend + frontend), runnable locally and on VMs:
+
+```bash
+# Local — test the whole platform with Docker Desktop:
+cp .env.docker.example .env
+docker compose up --build           # web :4001 · API :4000/docs
+
+# Production (VMs, single HTTPS origin behind Caddy, external Postgres):
+docker compose -f compose.prod.yaml up -d --build
+```
+
+Step-by-step guide (env matrix, external DB + pgvector, admin seed,
+troubleshooting): **[`docs/deployment/README.md`](docs/deployment/README.md)**.
+
 ## Getting Started
 
 ### Prerequisites

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1.7
+#
+# TACO-IDE API (Fastify) — build context MUST be the repo root:
+#   docker build -f apps/api/Dockerfile --target runner -t taco-api .
+#
+# Design: the API runs straight from TypeScript source via `tsx` (the exact same
+# way `npm run dev` does), with NO tsup/bundling step. Reasons:
+#   * @repo/infra is a workspace package shipped as raw .ts (its "exports" point
+#     at ./src/*.ts), so a tsx ESM loader is required at runtime regardless.
+#   * Skipping tsup also avoids rollup's platform-native optional dependency,
+#     which `npm ci` fails to install from a lockfile generated on another OS
+#     (npm optional-deps bug npm/cli#4828).
+# tsx uses esbuild for on-the-fly transpile; cold start costs a couple of extra
+# seconds, irrelevant for a long-running server.
+#
+# Targets:
+#   runner  -> the long-running API server (default)
+#   migrate -> one-shot job: drizzle-kit migrate + prod seed (see compose)
+
+# =============================================================================
+# Stage 1: deps — install the FULL workspace dependency tree. All workspace
+# package.json files are copied so npm hoists deterministically.
+# =============================================================================
+FROM node:22-alpine AS deps
+WORKDIR /repo
+
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/infra/package.json ./packages/infra/package.json
+COPY packages/types/package.json ./packages/types/package.json
+COPY packages/eslint-config/package.json ./packages/eslint-config/package.json
+COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --ignore-scripts
+
+# =============================================================================
+# Stage 2: runner — API server, run from source via tsx.
+# `COPY --from=deps /repo ./` brings the whole installed tree (root + any
+# per-workspace node_modules npm did not hoist, e.g. better-auth under
+# packages/infra), then source is overlaid on top.
+# =============================================================================
+FROM node:22-alpine AS runner
+# pandoc: converts non-PDF Knowledge Base uploads
+# (apps/api/src/services/document-parser.ts shells out to `pandoc`). PDFs are
+# parsed in-process by pdf-parse (no binary).
+RUN apk add --no-cache pandoc && adduser -S -u 1001 app
+WORKDIR /repo
+ENV NODE_ENV=production
+ENV PORT=4000
+
+COPY --from=deps /repo ./
+COPY packages/ ./packages/
+COPY apps/api/ ./apps/api/
+
+# Runtime writes by the non-root `app` user:
+#  - uploads/ (Knowledge Base files; mount a volume here in compose)
+#  - apps/api/src/swagger.yaml (the server re-exports the OpenAPI spec on boot)
+RUN mkdir -p /repo/uploads/documents \
+    && chown -R app /repo/uploads /repo/apps/api/src
+
+USER app
+EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=25s --retries=5 \
+    CMD wget -qO- http://127.0.0.1:4000/v1/status >/dev/null 2>&1 || exit 1
+
+CMD ["node", "--import", "tsx/esm", "apps/api/src/index.ts"]
+
+# =============================================================================
+# Stage 3: migrate — one-shot DB provisioning (drizzle migrations + prod seed).
+# Runs to completion before the API starts. drizzle-kit/tsx come from node_modules;
+# the drizzle.config, the drizzle/ SQL folder and the schema live under
+# packages/infra. The default command runs the PROD-safe seed; compose.yaml
+# overrides it for local (adds the dev fixtures).
+# =============================================================================
+FROM node:22-alpine AS migrate
+WORKDIR /repo
+ENV NODE_ENV=production
+
+COPY --from=deps /repo ./
+COPY packages/ ./packages/
+
+WORKDIR /repo/packages/infra
+CMD ["sh", "-c", "npx drizzle-kit migrate --config ./drizzle.config.ts && npx tsx src/db/seeds/prod.ts"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+#
+# TACO-IDE Web (Next.js 16, standalone) — build context MUST be the repo root:
+#   docker build -f apps/web/Dockerfile \
+#     --build-arg NEXT_PUBLIC_API_URL=https://taco.example.edu -t taco-web .
+#
+# IMPORTANT: NEXT_PUBLIC_API_URL is inlined into the client bundle at BUILD time.
+# Setting it at `docker run` has NO effect — pass it as --build-arg (compose does
+# this via build.args). To change the API origin you must rebuild the web image.
+#
+# Requires `output: "standalone"` + `outputFileTracingRoot` in next.config.mjs
+# (already configured). The web image needs NO database/LLM/auth secrets — it is
+# a pure client of the API; only NEXT_PUBLIC_API_URL matters, at build time.
+
+ARG NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# =============================================================================
+# Stage 1: deps — install the FULL workspace dependency tree (all workspace
+# package.json files copied so npm hoists deterministically; this avoids
+# Next's TS check failing to find @types/* at build time).
+# =============================================================================
+FROM node:22-alpine AS deps
+WORKDIR /repo
+
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/infra/package.json ./packages/infra/package.json
+COPY packages/types/package.json ./packages/types/package.json
+COPY packages/eslint-config/package.json ./packages/eslint-config/package.json
+COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --ignore-scripts
+
+# =============================================================================
+# Stage 2: builder — next build -> apps/web/.next/standalone. Bring the whole
+# installed tree from deps, then overlay source.
+# =============================================================================
+FROM node:22-alpine AS builder
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+WORKDIR /repo
+
+COPY --from=deps /repo ./
+COPY packages/ ./packages/
+COPY apps/web/ ./apps/web/
+
+RUN npm run build --workspace=apps/web
+
+# =============================================================================
+# Stage 3: runner — minimal standalone Next.js server
+# =============================================================================
+FROM node:22-alpine AS runner
+RUN adduser -S -u 1001 app
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+# HOSTNAME=0.0.0.0 is required for the standalone server to bind all interfaces.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=4001
+
+# The standalone tree (traced from the monorepo root) contains apps/web/server.js
+# plus a minimal node_modules. Static assets and public/ are NOT included and
+# must be copied alongside it.
+COPY --from=builder /repo/apps/web/.next/standalone ./
+COPY --from=builder /repo/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /repo/apps/web/public ./apps/web/public
+
+USER app
+EXPOSE 4001
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,9 +1,16 @@
 import createNextIntlPlugin from "next-intl/plugin";
+import path from "node:path";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    // Self-contained server bundle for Docker (.next/standalone).
+    output: "standalone",
+    // In a monorepo, trace the workspace root so hoisted node_modules are
+    // copied into the standalone output; without this the bundle is incomplete
+    // and crashes at runtime.
+    outputFileTracingRoot: path.join(import.meta.dirname, "../../"),
     images: {
         remotePatterns: [
             {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,8 +12,12 @@ const publicPaths = [
 export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // Get Better Auth session cookie
-  const sessionToken = request.cookies.get("better-auth.session_token")?.value;
+  // Get Better Auth session cookie. In production (HTTPS) Better Auth emits the
+  // `__Secure-` prefixed cookie; in development it uses the bare name. Check both
+  // so the SSR gate works in every environment.
+  const sessionToken =
+    request.cookies.get("better-auth.session_token")?.value ??
+    request.cookies.get("__Secure-better-auth.session_token")?.value;
   const isLoggedIn = !!sessionToken;
 
   // Check if current path is an auth route (login, signup, etc.)

--- a/apps/web/src/store/useChatStore.ts
+++ b/apps/web/src/store/useChatStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3344";
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
 
 export interface ChatMessage {
   role: "user" | "assistant";

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,103 @@
+# TACO-IDE — PRODUCTION stack for the VMs (backend + frontend only).
+#
+# The database is NOT managed here: point DATABASE_URL at your external Postgres
+# (it MUST have the pgvector extension available — see docs/deployment/README.md).
+#
+# Single public origin behind Caddy (auto-HTTPS). Only Caddy exposes ports
+# (80/443); api/web stay on the internal network.
+#
+#   # 1. Put real values in a root .env (DOMAIN, DATABASE_URL, secrets, keys)
+#   # 2. Build + start:
+#   docker compose -f compose.prod.yaml up -d --build
+#   # 3. (idempotent) migrations run automatically via the `migrate` service.
+#
+# Required in .env: DOMAIN, DATABASE_URL, BETTER_AUTH_SECRET (>=32), LLM_API_KEY.
+# Strongly recommended in prod: RESEND_API_KEY + EMAIL_FROM (else new users can't
+# verify their email and cannot sign in). Optional: EMBEDDING_*, LANGFUSE_*,
+# PLATFORM_ADMIN_* (auto-creates a platform admin on first migrate).
+
+name: taco-ide-prod
+
+services:
+  # One-shot DB provisioning against the EXTERNAL Postgres: drizzle migrations
+  # (incl. CREATE EXTENSION vector) + prod-safe seed (model, default TA, and the
+  # platform admin if PLATFORM_ADMIN_* are set). Idempotent; gates the API.
+  migrate:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: migrate
+    restart: "no"
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: ${DATABASE_URL:?set DATABASE_URL to your external Postgres (append ?sslmode=require if needed)}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET (>=32 chars)}
+      BETTER_AUTH_URL: https://${DOMAIN:?set DOMAIN}
+      FRONTEND_URL: https://${DOMAIN}
+      LLM_API_KEY: ${LLM_API_KEY:?set LLM_API_KEY (required at boot)}
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: runner
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      PORT: "4000"
+      DATABASE_URL: ${DATABASE_URL:?set DATABASE_URL}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?set BETTER_AUTH_SECRET (>=32 chars)}
+      BETTER_AUTH_URL: https://${DOMAIN:?set DOMAIN}
+      FRONTEND_URL: https://${DOMAIN}
+      LLM_API_KEY: ${LLM_API_KEY:?set LLM_API_KEY}
+    volumes:
+      - uploads:/repo/uploads
+    expose:
+      - "4000"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      args:
+        # Single origin: the browser calls https://DOMAIN/v1/... which Caddy
+        # routes to the API. Baked at build time — rebuild web if DOMAIN changes.
+        NEXT_PUBLIC_API_URL: https://${DOMAIN:?set DOMAIN}
+    restart: unless-stopped
+    environment:
+      PORT: "4001"
+      HOSTNAME: 0.0.0.0
+    expose:
+      - "4001"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    environment:
+      DOMAIN: ${DOMAIN:?set DOMAIN}
+      # ACME_EMAIL: ${ACME_EMAIL:-}   # optional; also uncomment the block in Caddyfile
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - web
+      - api
+
+volumes:
+  uploads:
+  caddy_data:
+  caddy_config:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,108 @@
+# TACO-IDE — LOCAL full stack for Docker Desktop.
+#
+#   docker compose up --build
+#
+# Brings up: db (pgvector) -> migrate (schema + seed, runs once) -> api -> web.
+# Open http://localhost:4001 (web) and http://localhost:4000/docs (API).
+#
+# Secrets/extra config are read from a root `.env` if present (optional locally;
+# sane defaults below let a fresh clone boot). For PRODUCTION on the VMs use
+# compose.prod.yaml instead (no db service, external Postgres, Caddy + HTTPS).
+
+name: taco-ide
+
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: taco
+    ports:
+      # Host 5433 -> container 5432 (avoids clashing with a local Postgres on
+      # 5432). Only for host access/debugging; the app talks to db:5432 inside.
+      - "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d taco"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  # One-shot: applies drizzle migrations (incl. CREATE EXTENSION vector) then
+  # seeds base data + dev fixtures (demo professor/aluno accounts). Exits 0.
+  migrate:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: migrate
+    restart: "no"
+    # Optional: layer real keys from a root .env (PLATFORM_ADMIN_*, EMBEDDING_*, ...)
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      NODE_ENV: development
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/taco
+      BETTER_AUTH_URL: http://localhost:4000
+      FRONTEND_URL: http://localhost:4001
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-better-auth-secret-change-me-0123456789}
+      LLM_API_KEY: ${LLM_API_KEY:-local-dev-placeholder}
+    command:
+      - sh
+      - -c
+      - npx drizzle-kit migrate --config ./drizzle.config.ts && npx tsx src/db/seeds/base.ts && npx tsx src/db/seeds/dev.ts
+    depends_on:
+      db:
+        condition: service_healthy
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      target: runner
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      NODE_ENV: development
+      PORT: "4000"
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/taco
+      BETTER_AUTH_URL: http://localhost:4000
+      FRONTEND_URL: http://localhost:4001
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-better-auth-secret-change-me-0123456789}
+      LLM_API_KEY: ${LLM_API_KEY:-local-dev-placeholder}
+    ports:
+      - "4000:4000"
+    volumes:
+      - uploads:/repo/uploads
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+      args:
+        # Baked into the client bundle at build time. Browser talks to the API
+        # on the host-published port, so localhost:4000 is correct locally.
+        NEXT_PUBLIC_API_URL: http://localhost:4000
+    restart: unless-stopped
+    environment:
+      PORT: "4001"
+      HOSTNAME: 0.0.0.0
+    ports:
+      - "4001:4001"
+    depends_on:
+      api:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  uploads:

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,30 @@
+# Single public origin for TACO-IDE: web + API behind one HTTPS domain.
+# Caddy terminates TLS (auto Let's Encrypt/ZeroSSL) and routes by path:
+#   /v1/*, /api/*, /docs  -> api:4000
+#   everything else       -> web:4001
+# It also sets X-Forwarded-Proto/Host, which the API trusts (trustProxy: true).
+#
+# $DOMAIN is injected from the environment (see compose.prod.yaml).
+# To use a contact email for ACME, uncomment the global block and set $ACME_EMAIL.
+
+# {
+#     email {$ACME_EMAIL}
+# }
+
+{$DOMAIN} {
+    encode zstd gzip
+
+    # Allow Knowledge Base uploads (API multipart cap is 10MB).
+    request_body {
+        max_size 12MB
+    }
+
+    @api path /v1/* /api/* /docs /docs/*
+    handle @api {
+        reverse_proxy api:4000
+    }
+
+    handle {
+        reverse_proxy web:4001
+    }
+}

--- a/docs/deployment/GO-LIVE.md
+++ b/docs/deployment/GO-LIVE.md
@@ -1,0 +1,185 @@
+# Runbook de Go-Live (deploy real nas VMs)
+
+Checklist operacional para o dia de subir o TACO-IDE em produção. Para o guia de
+referência (arquitetura, matriz de env, troubleshooting) veja
+[`README.md`](./README.md). Aqui é só o passo a passo, em ordem.
+
+Topologia: **origem única HTTPS** (Caddy) → web + API no mesmo domínio; **banco
+PostgreSQL externo** (não containerizamos o banco).
+
+---
+
+## 0. Pré-requisitos (confirme ANTES de começar)
+
+- [ ] **VM** com Docker Engine + Docker Compose v2 (`docker compose version`).
+- [ ] **Portas 80 e 443** abertas no firewall/security group da VM.
+- [ ] **Domínio** (ex.: `taco.suaescola.edu`) com **registro DNS A/AAAA** já
+      apontando para o **IP público da VM**. Verifique:
+      `dig +short taco.suaescola.edu` → deve retornar o IP da VM.
+- [ ] **PostgreSQL externo** acessível pela VM, e a extensão **pgvector**
+      habilitada/permitida (RDS: `rds.allowed_extensions`; Azure: `azure.extensions`).
+      O usuário do `DATABASE_URL` precisa poder rodar `CREATE EXTENSION` OU a
+      extensão já estar criada por um admin.
+- [ ] **Chaves em mãos:** `LLM_API_KEY` (Azure OpenAI), `RESEND_API_KEY` (e-mail),
+      e, se for usar busca semântica do KB, `EMBEDDING_*`.
+
+> Teste a conexão com o banco a partir da VM antes de seguir:
+> `docker run --rm postgres:16 psql "$DATABASE_URL" -c 'select 1'`
+
+---
+
+## 1. Trazer o código e gerar segredos
+
+```bash
+git clone git@github.com:taco-ide/taco-ide.git && cd taco-ide
+git checkout main          # ou a tag/release que for subir
+
+cp .env.docker.example .env
+
+# Gere o secret do Better Auth (>= 32 chars) e cole no .env:
+openssl rand -base64 48
+```
+
+---
+
+## 2. Preencher o `.env`
+
+Edite o `.env` na raiz. **Obrigatórios** em produção:
+
+```env
+DOMAIN=taco.suaescola.edu
+DATABASE_URL=postgresql://USER:PASS@db-host:5432/taco?sslmode=require
+BETTER_AUTH_SECRET=<cole o openssl rand acima>
+LLM_API_KEY=<chave do provedor LLM>
+```
+
+**Fortemente recomendados** (sem e-mail, usuários novos não verificam a conta e
+não conseguem logar):
+
+```env
+RESEND_API_KEY=re_xxx
+EMAIL_FROM=noreply@suaescola.edu
+```
+
+**Opcionais:** `EMBEDDING_*` (KB), `PLATFORM_ADMIN_EMAIL/PASSWORD/NAME` (cria o
+admin de plataforma já no primeiro deploy), `LANGFUSE_*`.
+
+> `BETTER_AUTH_URL`, `FRONTEND_URL` e o `NEXT_PUBLIC_API_URL` (build do web) são
+> derivados de `https://${DOMAIN}` automaticamente — não precisa setar.
+
+Checagem rápida de que o compose lê tudo certo (não sobe nada):
+```bash
+docker compose -f compose.prod.yaml config >/dev/null && echo "env OK"
+```
+Se faltar um obrigatório, ele falha aqui dizendo qual variável.
+
+---
+
+## 3. Subir
+
+```bash
+docker compose -f compose.prod.yaml up -d --build
+```
+
+Ordem garantida: **`migrate` (migrations + seed) → `api` → `web` → `caddy`**.
+
+---
+
+## 4. Verificar (nesta ordem)
+
+```bash
+# 4.1 migrate terminou em exit 0 (rodou as migrations + seed):
+docker compose -f compose.prod.yaml logs migrate | tail -20
+
+# 4.2 todos os serviços de pé; api "healthy":
+docker compose -f compose.prod.yaml ps
+
+# 4.3 Caddy emitiu o certificado TLS (procure "certificate obtained"):
+docker compose -f compose.prod.yaml logs caddy | grep -i "certificate\|tls\|error" | tail
+
+# 4.4 health da API pela internet:
+curl -fsS https://taco.suaescola.edu/v1/status
+
+# 4.5 site no ar:
+curl -s -o /dev/null -w "%{http_code}\n" https://taco.suaescola.edu/
+```
+
+- [ ] `migrate` exit 0
+- [ ] `api` healthy, `web`/`caddy` up
+- [ ] certificado HTTPS emitido (cadeado válido no navegador)
+- [ ] `/v1/status` responde 200
+- [ ] consegue logar com o admin (ou criar/verificar um usuário)
+
+---
+
+## 5. Pós-deploy
+
+- **Admin:** se setou `PLATFORM_ADMIN_*`, o admin já foi criado. Senão, crie o
+  primeiro usuário e promova conforme o fluxo da plataforma.
+- **Smoke test funcional:** logar, criar uma turma, criar um desafio, subir um
+  documento no Knowledge Base (valida `pandoc` + uploads + embeddings).
+
+---
+
+## 6. Atualizar (próximos deploys)
+
+```bash
+cd taco-ide
+git pull                 # ou checkout da nova tag
+docker compose -f compose.prod.yaml up -d --build
+```
+
+- Migrations rodam de novo automaticamente (idempotentes).
+- **Mudou o `DOMAIN`?** o web é reconstruído pelo `--build` (o `NEXT_PUBLIC_API_URL`
+  é embutido no bundle em tempo de build).
+
+---
+
+## 7. Rollback
+
+```bash
+# Voltar para a versão anterior do código:
+git checkout <tag-ou-commit-anterior>
+docker compose -f compose.prod.yaml up -d --build
+```
+
+⚠️ **Migrations não têm rollback automático.** Se uma migration nova quebrou,
+restaure o banco a partir do backup do provedor ANTES de voltar o código.
+Por isso: **faça backup do banco antes de cada deploy** que inclua migration.
+
+---
+
+## 8. Operação do dia a dia
+
+```bash
+docker compose -f compose.prod.yaml logs -f api      # logs ao vivo
+docker compose -f compose.prod.yaml restart api      # reiniciar um serviço
+docker compose -f compose.prod.yaml down             # parar tudo (mantém volumes)
+docker compose -f compose.prod.yaml ps               # status
+```
+
+**Backup dos uploads do Knowledge Base** (volume `uploads`):
+```bash
+docker run --rm -v taco-ide-prod_uploads:/data -v "$PWD":/out alpine \
+  tar czf /out/uploads-$(date +%F).tgz -C /data .
+```
+
+**Onde ficam os dados:**
+- Banco → externo (backup pelo provedor).
+- Uploads do KB → volume Docker `uploads` na VM.
+- Certificados TLS → volume Docker `caddy_data` (renovação automática pelo Caddy).
+
+---
+
+## Se algo der errado
+
+| Sintoma | Causa provável | Ação |
+|---|---|---|
+| `migrate` falha em `CREATE EXTENSION vector` | usuário do DB sem privilégio / pgvector não liberado | habilitar pgvector no provedor; usar usuário com permissão |
+| API em crash-loop, `Invalid environment variables` | falta var obrigatória no `.env` | conferir `DATABASE_URL`, `BETTER_AUTH_SECRET` (≥32), `LLM_API_KEY` |
+| Caddy não pega certificado | DNS não aponta pra VM / 80-443 fechadas | `dig` o domínio, liberar portas, ver `logs caddy` |
+| Login entra em loop pra `/auth/login` | rodando código sem a correção do cookie `__Secure-` | usar `main` atualizada e rebuildar |
+| Front chama `localhost:4000` | `NEXT_PUBLIC_API_URL` embutido errado | rebuildar o web com `--build` após ajustar `DOMAIN` |
+| Upload grande dá 413 | limite de body | já liberado 12MB no Caddyfile; ajustar se trocar de proxy |
+
+Detalhes e mais casos em [`README.md`](./README.md#troubleshooting).

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,274 @@
+# Deploy do TACO-IDE com Docker
+
+Guia para (1) **testar a plataforma inteira localmente** com o Docker Desktop e
+(2) **subir nas VMs** em produção. Backend (Fastify) e frontend (Next.js) rodam
+em containers; o **banco em produção é externo** (você fornece a `DATABASE_URL`).
+
+---
+
+## Arquitetura
+
+```
+                 ┌───────────────────────── rede docker ─────────────────────────┐
+  navegador ───► │  caddy (80/443, só prod)                                        │
+   (HTTPS)       │     ├─ /v1/* /api/* /docs ─► api  (Fastify, :4000)              │
+                 │     └─ resto ─────────────► web  (Next.js standalone, :4001)    │
+                 │                               │                                  │
+                 │                          migrate (job único: migrations + seed)  │
+                 └───────────────────────────────┼──────────────────────────────  ┘
+                                                  ▼
+                                         PostgreSQL + pgvector
+                                  (LOCAL: container | PROD: externo)
+```
+
+- **Origem única (prod):** web e API são servidos pelo **mesmo domínio HTTPS**
+  via Caddy. Isso evita qualquer dor de cookie cross-site no login.
+- **`migrate`** roda **uma vez** antes da API: aplica as migrations do Drizzle
+  (incluindo `CREATE EXTENSION vector`) e o seed. É idempotente.
+- **`uploads`** (arquivos do Knowledge Base) ficam num volume Docker.
+
+### Arquivos desta infra
+
+| Arquivo | Para quê |
+|---|---|
+| `compose.yaml` | Stack **local** completo (inclui o banco em container) |
+| `compose.prod.yaml` | Stack de **produção** (só back+front+Caddy, banco externo) |
+| `apps/api/Dockerfile` | Imagem da API (alvos `runner` e `migrate`); instala `pandoc` |
+| `apps/web/Dockerfile` | Imagem do web (Next standalone; `NEXT_PUBLIC_API_URL` no build) |
+| `deploy/Caddyfile` | Reverse proxy de origem única + HTTPS automático |
+| `.dockerignore` | Mantém o build context enxuto |
+| `.env.docker.example` | Modelo de variáveis de ambiente |
+
+---
+
+## Parte A — Testar localmente (Docker Desktop)
+
+Pré-requisitos: **Docker Desktop** rodando. Nada de Node/Postgres/Pandoc na
+máquina — está tudo nas imagens.
+
+```bash
+# 1. (opcional) variáveis. O stack local sobe com defaults; só precisa de
+#    LLM_API_KEY se for exercitar as features de IA.
+cp .env.docker.example .env       # edite LLM_API_KEY se quiser IA
+
+# 2. Sobe tudo (db -> migrate -> api -> web). A 1ª vez compila as imagens.
+docker compose up --build
+
+# (em outro terminal) acompanhe quando ficar pronto:
+#   db        healthy
+#   migrate   exited (0)
+#   api       healthy
+#   web       running
+docker compose ps
+```
+
+Acesse:
+
+- **Web:** http://localhost:4001
+- **API / Swagger:** http://localhost:4000/docs
+- **Health da API:** http://localhost:4000/v1/status
+
+**Contas de demo** (criadas pelo seed dev local):
+
+- Professor: `professor@taco-demo.local`
+- Aluno: `aluno@taco-demo.local`
+- Senha padrão das fixtures de dev: `Teste123!@`
+
+> Localmente o stack roda com `NODE_ENV=development`: o cookie de sessão **não**
+> é `Secure` (funciona em HTTP) e a verificação de e-mail fica desligada — dá pra
+> cadastrar/logar na hora. `localhost:4001` e `localhost:4000` são o **mesmo
+> site** para o navegador, então o cookie `SameSite=Lax` é enviado normalmente.
+
+### Comandos úteis (local)
+
+```bash
+docker compose logs -f api          # logs da API
+docker compose logs -f web          # logs do web
+docker compose restart api          # reinicia um serviço
+docker compose down                 # para tudo (mantém os dados no volume)
+docker compose down -v              # para tudo e APAGA o banco/uploads (reset total)
+
+# Reaplicar migrations/seed manualmente (ex.: recriou o banco):
+docker compose run --rm migrate
+
+# Rodar só o seed de fixtures de demo de novo:
+docker compose run --rm -e NODE_ENV=development migrate \
+  npx tsx src/db/seeds/dev.ts
+```
+
+> O Postgres local é publicado em **`localhost:5433`** (host) → `5432` (container),
+> pra não colidir com um Postgres já rodando na 5432. Para abrir o Drizzle Studio
+> ou um cliente SQL apontando pro banco do container, use
+> `postgresql://postgres:postgres@localhost:5433/taco`.
+
+---
+
+## Parte B — Deploy nas VMs (produção, domínio + HTTPS)
+
+### B.0 Pré-requisitos
+
+Na VM:
+- **Docker Engine + Docker Compose v2** instalados.
+- Portas **80 e 443** abertas (Caddy faz o HTTPS automático).
+- Um **domínio** (ex.: `taco.suaescola.edu`) com **registro DNS A/AAAA**
+  apontando para o IP da VM. (Sem isso o Let's Encrypt não emite o certificado.)
+
+Externo:
+- Um **PostgreSQL** acessível pela VM, **com a extensão pgvector disponível**.
+  - Postgres gerenciado (RDS/Azure/Cloud SQL) normalmente exige **habilitar a
+    extensão antes** (ex.: RDS `rds.allowed_extensions`, Azure `azure.extensions`)
+    e que o usuário do `DATABASE_URL` possa rodar `CREATE EXTENSION`.
+  - Use SSL: acrescente `?sslmode=require` na `DATABASE_URL`.
+
+### B.1 Trazer o código e configurar o `.env`
+
+```bash
+git clone <repo> taco-ide && cd taco-ide
+cp .env.docker.example .env
+```
+
+Edite o `.env` com os valores **reais**. Mínimo obrigatório em produção:
+
+```env
+DOMAIN=taco.suaescola.edu
+DATABASE_URL=postgresql://USER:PASS@db-host:5432/taco?sslmode=require
+BETTER_AUTH_SECRET=<openssl rand -base64 48>
+LLM_API_KEY=<chave Azure OpenAI / provedor LLM>
+```
+
+Fortemente recomendado em produção (senão usuários novos não verificam e-mail e
+**não conseguem logar**):
+
+```env
+RESEND_API_KEY=re_xxx
+EMAIL_FROM=noreply@suaescola.edu
+```
+
+Opcional: `EMBEDDING_*` (busca semântica do Knowledge Base), `PLATFORM_ADMIN_*`
+(cria um admin de plataforma no primeiro `migrate`), `LANGFUSE_*`.
+
+> O `compose.prod.yaml` deriva `BETTER_AUTH_URL`, `FRONTEND_URL` e o
+> `NEXT_PUBLIC_API_URL` (build do web) a partir de `https://${DOMAIN}` — origem
+> única. Se algum obrigatório faltar, o `docker compose` **falha na hora**
+> dizendo qual variável setar.
+
+### B.2 Subir
+
+```bash
+docker compose -f compose.prod.yaml up -d --build
+```
+
+Ordem garantida: **`migrate` roda as migrations + seed → API sobe → web sobe →
+Caddy publica em HTTPS**. Acompanhe:
+
+```bash
+docker compose -f compose.prod.yaml logs -f migrate   # deve terminar em exit 0
+docker compose -f compose.prod.yaml ps
+docker compose -f compose.prod.yaml logs -f caddy      # emissão do certificado
+```
+
+Pronto: acesse `https://taco.suaescola.edu`. API em
+`https://taco.suaescola.edu/docs`.
+
+### B.3 Admin de plataforma
+
+Se você setou `PLATFORM_ADMIN_EMAIL` / `PLATFORM_ADMIN_PASSWORD` (≥12 chars) /
+`PLATFORM_ADMIN_NAME`, o `migrate` já criou o admin (verificado e ativo).
+Reexecutar o `migrate` com uma senha nova **rotaciona** a senha.
+
+### B.4 Atualizar (novo deploy)
+
+```bash
+git pull
+docker compose -f compose.prod.yaml up -d --build
+```
+
+- As migrations rodam de novo automaticamente (idempotentes).
+- **Se mudou o `DOMAIN`**, o web precisa ser reconstruído (o `--build` já faz):
+  o `NEXT_PUBLIC_API_URL` é embutido no bundle em tempo de build.
+
+### B.5 Backup / dados
+
+- **Banco:** é externo → use o backup do seu provedor.
+- **Uploads do Knowledge Base:** volume `uploads`. Backup:
+  ```bash
+  docker run --rm -v taco-ide-prod_uploads:/data -v "$PWD":/out alpine \
+    tar czf /out/uploads-backup.tgz -C /data .
+  ```
+
+---
+
+## Variáveis de ambiente (resumo)
+
+Legenda: **B** = usado no *build*, **R** = usado em *runtime*.
+
+| Variável | Serviço | Quando | Obrigatória | Observação |
+|---|---|---|---|---|
+| `DOMAIN` | web(B)/caddy/api | B+R | ✅ prod | Origem única HTTPS |
+| `DATABASE_URL` | api/migrate | R | ✅ | Postgres externo + `?sslmode=require` |
+| `BETTER_AUTH_SECRET` | api/migrate | R | ✅ (≥32) | Igual em todas as réplicas |
+| `LLM_API_KEY` | api/migrate | R | ✅ | API **não sobe** sem isso |
+| `NEXT_PUBLIC_API_URL` | web | **B** | ✅ | Embutido no build (= `https://DOMAIN`) |
+| `RESEND_API_KEY` + `EMAIL_FROM` | api | R | ⚠️ prod | Sem isso, verificação de e-mail trava login |
+| `BETTER_AUTH_URL` | api | R | auto | `https://DOMAIN` (derivado) |
+| `FRONTEND_URL` | api | R | auto | `https://DOMAIN` (derivado); usado no CORS e nos links de e-mail |
+| `EMBEDDING_*` | api | R | ❌ | Knowledge Base; mantenha `EMBEDDING_DIMENSIONS=1536` |
+| `PLATFORM_ADMIN_*` | migrate | R | ❌ | Cria admin no 1º migrate |
+| `LANGFUSE_*`, `OPENROUTER_API_KEY`, `CLOUDFLARE_TURNSTILE_SECRET`, `CODE_EXEC_API_URL` | api | R | ❌ | Opcionais |
+| `PORT` / `HOSTNAME` | api/web | R | auto | `4000` / `4001` / `0.0.0.0` |
+
+---
+
+## Troubleshooting
+
+**API em crash-loop logo no start (`Invalid environment variables`).**
+Falta uma var obrigatória (`DATABASE_URL`, `BETTER_AUTH_SECRET` ≥32,
+`BETTER_AUTH_URL`, `LLM_API_KEY`). O `env.ts` valida tudo na importação. Cheque
+o `.env`.
+
+**`migrate` falha em `CREATE EXTENSION "vector"`.**
+O usuário do `DATABASE_URL` não tem privilégio, ou a extensão não está
+liberada no Postgres gerenciado. Habilite pgvector (allow-list) e/ou use um
+usuário com permissão. Nunca use `db:push` num banco zerado — ele pula os
+arquivos SQL e não cria a extensão; sempre `migrate` (é o que o job faz).
+
+**Loop de redirect pro `/auth/login` em produção (usuário logado é "deslogado").**
+É o bug do nome do cookie em HTTPS. Já corrigido (o middleware lê
+`__Secure-better-auth.session_token`). Garanta que está rodando o código
+atualizado e reconstrua o web.
+
+**Chamadas do front vão pra `localhost:4000` em produção.**
+O `NEXT_PUBLIC_API_URL` foi embutido errado no build. Ele é **build-time**:
+reconstrua o web com `--build` após ajustar `DOMAIN`.
+
+**CORS bloqueando o front / links de e-mail apontando pra localhost.**
+`FRONTEND_URL` está errado. Na origem única ele é `https://DOMAIN` (derivado);
+confirme o `DOMAIN`.
+
+**Upload de documento grande falha (413).**
+A API aceita até 10MB por arquivo; o Caddyfile já libera 12MB no proxy. Se usar
+outro proxy na frente, ajuste o `client_max_body_size`/limite equivalente.
+
+**Caddy não emite certificado.**
+DNS do `DOMAIN` precisa apontar pra VM e as portas 80/443 abertas. Veja
+`docker compose -f compose.prod.yaml logs caddy`.
+
+**Air-gapped / sem internet de saída.**
+IA, embeddings e execução de código chamam serviços externos (Azure OpenAI,
+endpoint de embeddings, Piston em `emkc.org`). Se a saída for restrita,
+auto-hospede e sobrescreva `LLM_API_BASE` / `EMBEDDING_API_URL` /
+`CODE_EXEC_API_URL`.
+
+---
+
+## Notas de design (por que assim)
+
+- **`node --import tsx/esm` na API:** o `tsup` externaliza o pacote `@repo/infra`,
+  que é distribuído como `.ts` cru (sem build). Por isso a imagem carrega o
+  `tsx` e o `packages/infra/src` e inicia com esse loader — `node dist/index.js`
+  puro não resolveria esses imports.
+- **`output: "standalone"` no Next + `outputFileTracingRoot`:** gera um bundle
+  self-contained com o `node_modules` mínimo traçado a partir da raiz do
+  monorepo. Imagem web pequena.
+- **Banco só local:** em produção você aponta a `DATABASE_URL` para o Postgres
+  externo; o `compose.prod.yaml` não sobe banco.


### PR DESCRIPTION
## O que é

Infra Docker para subir o TACO-IDE **nas VMs** (produção) e **testar o stack inteiro localmente** com o Docker Desktop. Backend + frontend em containers; em produção o **banco é externo** (só apontamos `DATABASE_URL`).

## Topologia

- **Local** (`compose.yaml`): `db` (pgvector) → `migrate` (migrations + seed) → `api` → `web`, tudo em `localhost`.
- **Produção** (`compose.prod.yaml`): `migrate` → `api` → `web` → `caddy`, **origem única HTTPS** (Caddy roteia `/v1`,`/api`,`/docs` → API e o resto → web) com TLS automático por `DOMAIN`. **Sem banco** — Postgres externo.

## Arquivos

| Arquivo | Para quê |
|---|---|
| `apps/api/Dockerfile` | API (targets `runner` + `migrate`); roda via `tsx`, instala `pandoc`, healthcheck, volume de uploads |
| `apps/web/Dockerfile` | Web em Next.js `standalone`; `NEXT_PUBLIC_API_URL` é build-arg |
| `compose.yaml` / `compose.prod.yaml` | Stack local / produção |
| `deploy/Caddyfile` | Reverse proxy single-origin + HTTPS |
| `.dockerignore`, `.env.docker.example` | Build context enxuto + modelo de env |
| `docs/deployment/README.md` | Guia de referência (arquitetura, matriz de env, troubleshooting) |
| `docs/deployment/GO-LIVE.md` | **Runbook passo a passo** para o deploy real |

## Mudanças no código da app (necessárias pro deploy)

- `fix(web)`: middleware lê o cookie `__Secure-better-auth.session_token` (em HTTPS o Better Auth usa esse nome; sem isso, usuário logado entra em loop pra `/auth/login`).
- `fix(web)`: fallback da base URL do chat 3344 → 4000.
- `feat(web)`: `output: 'standalone'` + `outputFileTracingRoot` no `next.config.mjs`.

## Decisões de design

- **Banco externo em prod**: o `compose.prod.yaml` não sobe Postgres. O guia cobre habilitar a extensão **pgvector** em Postgres gerenciado (RDS/Azure exigem allow-list) e usar `?sslmode=require`.
- **API roda do fonte TS via `tsx`** (sem `tsup` no Docker): `@repo/infra` é distribuído como `.ts` cru (precisa do loader de qualquer forma) e isso contorna o bug do npm (npm/cli#4828) em que o binário nativo do `rollup` não instala a partir de lockfile gerado em outro SO.
- **Origem única** atrás do Caddy evita dor de cookie cross-site.

## Como testei (local, Docker Desktop)

Validado end-to-end com `docker compose up --build`:

- ✅ `db` healthy → `migrate` exit 0 (migrations incl. `CREATE EXTENSION vector` + base + dev seeds)
- ✅ `api` healthy: `GET /v1/status` → 200, `/docs` → 200
- ✅ `web`: `/` → 200 (`<title>TACO-IDE</title>`), `/auth/login` → 200
- ✅ **login real**: `POST /v1/auth/sign-in/email` (`professor@taco-demo.local`) → 200 com cookie `better-auth.session_token` + headers de CORS corretos
- ✅ build de **produção** (`compose.prod.yaml build`) também passa

## Como rodar

```bash
# Local
cp .env.docker.example .env
docker compose up --build            # web :4001 · API :4000/docs
# demo: professor@taco-demo.local / Teste123!@

# Produção (VM)
docker compose -f compose.prod.yaml up -d --build
```

## O que o time precisa providenciar no deploy real

- Domínio + DNS apontando pra VM, portas 80/443 abertas.
- Postgres externo com pgvector habilitado.
- Chaves: `LLM_API_KEY` (obrigatória no boot), `RESEND_API_KEY` (efetivamente obrigatória em prod, senão verificação de e-mail trava login), `EMBEDDING_*` (opcional, KB).

Passo a passo completo: `docs/deployment/GO-LIVE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
